### PR TITLE
UTF8 String serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,15 +548,16 @@ If you request it, there is a possibility to make a detuned Unity version. Pleas
 
 Binary wire format specification
 ---
-The type of `T` defined in `Serialize<T>` and `Deserialize<T>` is called C# schema. MemoryPack format is not self described format. Deserialize requires the corresponding C# schema. Four types exist as internal representations of binaries, but types cannot be determined without a C# schema.
+The type of `T` defined in `Serialize<T>` and `Deserialize<T>` is called C# schema. MemoryPack format is not self described format. Deserialize requires the corresponding C# schema. Five types exist as internal representations of binaries, but types cannot be determined without a C# schema.
 
 There are no endian specifications. It is not possible to convert on machines with different endianness. However modern computers are usually little-endian.
 
-There are four value types of format.
+There are five value types of format.
 
 * Unmanaged struct
 * Object
 * Collection
+* String
 * Union
 
 ### Unmanaged struct
@@ -574,7 +575,14 @@ Object has 1byte unsigned byte as member count in header. Member count allows `0
 
 `[int length, values...]`
 
-Collection has 4byte signed interger as data count in header, `-1` represents `null`. Values store memorypack value for the number of length. String is collection(serialize as `ReadOnlySpan<char>`, in other words, UTF16).
+Collection has 4byte signed interger as data count in header, `-1` represents `null`. Values store memorypack value for the number of length.
+
+### String
+
+`(int utf16-length, utf16-value)`  
+`(int ~utf8-length, int utf16-length, utf8-value)`
+
+String has two-form, UTF16 and UTF8. If first 4byte signed integer is `-1`, represents null. `0`, represents empty. UTF16 is same as collection(serialize as `ReadOnlySpan<char>`, utf16-value's byte count is utf16-length * 2). If first signed integer <= `-2`, value is encoded by UTF8. utf8-length is encoded in complement, `~utf8-length` to retrieve length. Next signed integer is utf16-length, it allows `-1` that represents unknown length. utf8-value store byte value for the number of utf8-length.
 
 ### Union
 

--- a/sandbox/Benchmark/Benchmarks/DeserializeTest.cs
+++ b/sandbox/Benchmark/Benchmarks/DeserializeTest.cs
@@ -18,10 +18,10 @@ using System.Threading.Tasks;
 
 namespace Benchmark.Benchmarks;
 
-[GenericTypeArguments(typeof(int))]
-[GenericTypeArguments(typeof(Vector3[]))]
-[GenericTypeArguments(typeof(JsonResponseModel))]
-[GenericTypeArguments(typeof(NeuralNetworkLayerModel))]
+//[GenericTypeArguments(typeof(int))]
+//[GenericTypeArguments(typeof(Vector3[]))]
+//[GenericTypeArguments(typeof(JsonResponseModel))]
+//[GenericTypeArguments(typeof(NeuralNetworkLayerModel))]
 public class DeserializeTest<T> : SerializerTestBase<T>
 {
     //SerializerSessionPool pool;
@@ -51,13 +51,13 @@ public class DeserializeTest<T> : SerializerTestBase<T>
         payloadJson = JsonSerializer.SerializeToUtf8Bytes(value);
     }
 
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public T MessagePackDeserialize()
     {
         return MessagePackSerializer.Deserialize<T>(payloadMessagePack);
     }
 
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public T? MemoryPackDeserialize()
     {
         return MemoryPackSerializer.Deserialize<T>(payloadMemoryPack);

--- a/sandbox/Benchmark/Benchmarks/SerializeTest.cs
+++ b/sandbox/Benchmark/Benchmarks/SerializeTest.cs
@@ -30,10 +30,10 @@ namespace Benchmark.Benchmarks;
 //[GenericTypeArguments(typeof(MyClass))]
 
 
-//[GenericTypeArguments(typeof(int))]
-//[GenericTypeArguments(typeof(Vector3[]))]
-//[GenericTypeArguments(typeof(JsonResponseModel))]
-//[GenericTypeArguments(typeof(NeuralNetworkLayerModel))]
+[GenericTypeArguments(typeof(int))]
+[GenericTypeArguments(typeof(Vector3[]))]
+[GenericTypeArguments(typeof(JsonResponseModel))]
+[GenericTypeArguments(typeof(NeuralNetworkLayerModel))]
 [CategoriesColumn]
 [PayloadColumn]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
@@ -70,16 +70,22 @@ public class SerializeTest<T> : SerializerTestBase<T>
         jsonWriter = new Utf8JsonWriter(writer);
     }
 
-    [Benchmark(Baseline = true), BenchmarkCategory(Categories.Bytes)]
+    [Benchmark, BenchmarkCategory(Categories.Bytes)]
     public byte[] MessagePackSerialize()
     {
         return MessagePackSerializer.Serialize(value);
     }
 
-    [Benchmark, BenchmarkCategory(Categories.Bytes)]
+    [Benchmark(Baseline = true), BenchmarkCategory(Categories.Bytes)]
     public byte[] MemoryPackSerialize()
     {
         return MemoryPackSerializer.Serialize(value, MemoryPackSerializeOptions.Default);
+    }
+
+    [Benchmark, BenchmarkCategory(Categories.Bytes)]
+    public byte[] MemoryPackSerializeUtf16()
+    {
+        return MemoryPackSerializer.Serialize(value, MemoryPackSerializeOptions.Utf16);
     }
 
     // requires T:new(), can't test it.
@@ -113,17 +119,24 @@ public class SerializeTest<T> : SerializerTestBase<T>
     //    return orleansSerializer.SerializeToArray(value);
     //}
 
-    [Benchmark(Baseline = true), BenchmarkCategory(Categories.BufferWriter)]
+    [Benchmark, BenchmarkCategory(Categories.BufferWriter)]
     public void MessagePackBufferWriter()
     {
         MessagePackSerializer.Serialize(writer, value);
         writer.Clear();
     }
 
-    [Benchmark, BenchmarkCategory(Categories.BufferWriter)]
+    [Benchmark(Baseline = true), BenchmarkCategory(Categories.BufferWriter)]
     public void MemoryPackBufferWriter()
     {
         MemoryPackSerializer.Serialize(writer, value);
+        writer.Clear();
+    }
+
+    [Benchmark, BenchmarkCategory(Categories.BufferWriter)]
+    public void MemoryPackBufferWriterUtf16()
+    {
+        MemoryPackSerializer.Serialize(writer, value, MemoryPackSerializeOptions.Utf16);
         writer.Clear();
     }
 

--- a/sandbox/Benchmark/Benchmarks/SerializeTest.cs
+++ b/sandbox/Benchmark/Benchmarks/SerializeTest.cs
@@ -30,10 +30,10 @@ namespace Benchmark.Benchmarks;
 //[GenericTypeArguments(typeof(MyClass))]
 
 
-[GenericTypeArguments(typeof(int))]
-[GenericTypeArguments(typeof(Vector3[]))]
-[GenericTypeArguments(typeof(JsonResponseModel))]
-[GenericTypeArguments(typeof(NeuralNetworkLayerModel))]
+//[GenericTypeArguments(typeof(int))]
+//[GenericTypeArguments(typeof(Vector3[]))]
+//[GenericTypeArguments(typeof(JsonResponseModel))]
+//[GenericTypeArguments(typeof(NeuralNetworkLayerModel))]
 [CategoriesColumn]
 [PayloadColumn]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
@@ -79,7 +79,7 @@ public class SerializeTest<T> : SerializerTestBase<T>
     [Benchmark, BenchmarkCategory(Categories.Bytes)]
     public byte[] MemoryPackSerialize()
     {
-        return MemoryPackSerializer.Serialize(value);
+        return MemoryPackSerializer.Serialize(value, MemoryPackSerializeOptions.Default);
     }
 
     // requires T:new(), can't test it.

--- a/sandbox/Benchmark/Benchmarks/Utf16VsUtf8.cs
+++ b/sandbox/Benchmark/Benchmarks/Utf16VsUtf8.cs
@@ -23,26 +23,26 @@ public class Utf16VsUtf8
     {
         this.japanese = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん";
         this.ascii = "abcedfghijklmnopqrstuvwxyz0123456789";
-        this.utf16Jpn = MemoryPackSerializer.Serialize(japanese, MemoryPackSerializeOptions.Default);
+        this.utf16Jpn = MemoryPackSerializer.Serialize(japanese, MemoryPackSerializeOptions.Utf16);
         this.utf8Jpn = MemoryPackSerializer.Serialize(japanese, MemoryPackSerializeOptions.Utf8);
-        this.utf16Ascii = MemoryPackSerializer.Serialize(ascii, MemoryPackSerializeOptions.Default);
+        this.utf16Ascii = MemoryPackSerializer.Serialize(ascii, MemoryPackSerializeOptions.Utf16);
         this.utf8Ascii = MemoryPackSerializer.Serialize(ascii, MemoryPackSerializeOptions.Utf8);
 
         this.largeAscii = RandomProvider.NextString(600);
-        this.utf16LargeAscii = MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Default);
+        this.utf16LargeAscii = MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Utf16);
         this.utf8LargeAscii = MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Utf8);
     }
 
     [Benchmark]
     public byte[] SerializeUtf16Ascii()
     {
-        return MemoryPackSerializer.Serialize(ascii);
+        return MemoryPackSerializer.Serialize(ascii, MemoryPackSerializeOptions.Utf16);
     }
 
     [Benchmark]
     public byte[] SerializeUtf16Japanese()
     {
-        return MemoryPackSerializer.Serialize(japanese);
+        return MemoryPackSerializer.Serialize(japanese, MemoryPackSerializeOptions.Utf16);
     }
 
     [Benchmark]
@@ -60,7 +60,7 @@ public class Utf16VsUtf8
     [Benchmark]
     public byte[] SerializeUtf16LargeAscii()
     {
-        return MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Default);
+        return MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Utf16);
     }
 
     [Benchmark]

--- a/sandbox/Benchmark/Benchmarks/Utf16VsUtf8.cs
+++ b/sandbox/Benchmark/Benchmarks/Utf16VsUtf8.cs
@@ -1,0 +1,107 @@
+﻿using Benchmark.BenchmarkNetUtilities;
+using BinaryPack.Models.Helpers;
+using MemoryPack;
+using System.Net.Http;
+
+namespace Benchmark.Benchmarks;
+
+[PayloadColumn]
+public class Utf16VsUtf8
+{
+    readonly string ascii;
+    readonly string japanese;
+    readonly string largeAscii;
+
+    readonly byte[] utf16Jpn;
+    readonly byte[] utf8Jpn;
+    readonly byte[] utf16Ascii;
+    readonly byte[] utf8Ascii;
+    readonly byte[] utf16LargeAscii;
+    readonly byte[] utf8LargeAscii;
+
+    public Utf16VsUtf8()
+    {
+        this.japanese = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん";
+        this.ascii = "abcedfghijklmnopqrstuvwxyz0123456789";
+        this.utf16Jpn = MemoryPackSerializer.Serialize(japanese, MemoryPackSerializeOptions.Default);
+        this.utf8Jpn = MemoryPackSerializer.Serialize(japanese, MemoryPackSerializeOptions.Utf8);
+        this.utf16Ascii = MemoryPackSerializer.Serialize(ascii, MemoryPackSerializeOptions.Default);
+        this.utf8Ascii = MemoryPackSerializer.Serialize(ascii, MemoryPackSerializeOptions.Utf8);
+
+        this.largeAscii = RandomProvider.NextString(600);
+        this.utf16LargeAscii = MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Default);
+        this.utf8LargeAscii = MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Utf8);
+    }
+
+    [Benchmark]
+    public byte[] SerializeUtf16Ascii()
+    {
+        return MemoryPackSerializer.Serialize(ascii);
+    }
+
+    [Benchmark]
+    public byte[] SerializeUtf16Japanese()
+    {
+        return MemoryPackSerializer.Serialize(japanese);
+    }
+
+    [Benchmark]
+    public byte[] SerializeUtf8Ascii()
+    {
+        return MemoryPackSerializer.Serialize(ascii, MemoryPackSerializeOptions.Utf8);
+    }
+
+    [Benchmark]
+    public byte[] SerializeUtf8Japanese()
+    {
+        return MemoryPackSerializer.Serialize(japanese, MemoryPackSerializeOptions.Utf8);
+    }
+
+    [Benchmark]
+    public byte[] SerializeUtf16LargeAscii()
+    {
+        return MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Default);
+    }
+
+    [Benchmark]
+    public byte[] SerializeUtf8LargeAscii()
+    {
+        return MemoryPackSerializer.Serialize(largeAscii, MemoryPackSerializeOptions.Utf8);
+    }
+
+    [Benchmark]
+    public void DeserializeUtf16Ascii()
+    {
+        MemoryPackSerializer.Deserialize<string>(utf16Ascii);
+    }
+
+    [Benchmark]
+    public void DeserializeUtf16Japanese()
+    {
+        MemoryPackSerializer.Deserialize<string>(utf16Jpn);
+    }
+
+    [Benchmark]
+    public void DeserializeUtf8Ascii()
+    {
+        MemoryPackSerializer.Deserialize<string>(utf8Ascii);
+    }
+
+    [Benchmark]
+    public void DeserializeUtf8Japanese()
+    {
+        MemoryPackSerializer.Deserialize<string>(utf8Jpn);
+    }
+
+    [Benchmark]
+    public void DeserializeUtf16LargeAscii()
+    {
+        MemoryPackSerializer.Deserialize<string>(utf16LargeAscii);
+    }
+
+    [Benchmark]
+    public void DeserializeUtf8LargeAscii()
+    {
+        MemoryPackSerializer.Deserialize<string>(utf8LargeAscii);
+    }
+}

--- a/sandbox/Benchmark/Micro/GetLocalVsStaticField.cs
+++ b/sandbox/Benchmark/Micro/GetLocalVsStaticField.cs
@@ -24,7 +24,7 @@ public class GetLocalVsStaticField
     [Benchmark(Baseline = true)]
     public void GetFromProvider()
     {
-        var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref bufferWriter);
+        var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref bufferWriter, MemoryPackSerializeOptions.Default);
         for (int i = 0; i < 100; i++)
         {
             writer.GetFormatter<int>().Serialize(ref writer, ref i);
@@ -35,7 +35,7 @@ public class GetLocalVsStaticField
     [Benchmark]
     public void GetFromLocal()
     {
-        var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref bufferWriter);
+        var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref bufferWriter, MemoryPackSerializeOptions.Default);
         var provider = writer.GetFormatter<int>();
         for (int i = 0; i < 100; i++)
         {

--- a/sandbox/Benchmark/Micro/RawSerialize.cs
+++ b/sandbox/Benchmark/Micro/RawSerialize.cs
@@ -71,7 +71,7 @@ public class RawSerialize
             bufWriter = staticWriter = new ReusableLinkedArrayBufferWriter(true, true);
         }
 
-        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer());
+        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer(), MemoryPackSerializeOptions.Default);
         try
         {
             if (value == null)
@@ -106,7 +106,7 @@ public class RawSerialize
             bufWriter = staticWriter = new ReusableLinkedArrayBufferWriter(true, true);
         }
 
-        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer());
+        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer(), MemoryPackSerializeOptions.Default);
         try
         {
             if (value == null)
@@ -140,7 +140,7 @@ public class RawSerialize
             bufWriter = staticWriter = new ReusableLinkedArrayBufferWriter(true, true);
         }
 
-        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer());
+        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer(), MemoryPackSerializeOptions.Default);
         try
         {
             if (value == null)
@@ -174,7 +174,7 @@ public class RawSerialize
             bufWriter = staticWriter = new ReusableLinkedArrayBufferWriter(true, true);
         }
 
-        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer());
+        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer(), MemoryPackSerializeOptions.Default);
         try
         {
             if (value == null)
@@ -208,7 +208,7 @@ public class RawSerialize
             bufWriter = staticWriter = new ReusableLinkedArrayBufferWriter(true, true);
         }
 
-        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer());
+        var writer = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref bufWriter, bufWriter.DangerousGetFirstBuffer(), MemoryPackSerializeOptions.Default);
         try
         {
             if (value == null)

--- a/sandbox/Benchmark/Micro/Utf8Decoding.cs
+++ b/sandbox/Benchmark/Micro/Utf8Decoding.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Unicode;
+using System.Threading.Tasks;
+
+namespace Benchmark.Micro;
+
+public class Utf8Decoding
+{
+    byte[] utf8bytes;
+    int utf8length;
+    int utf16length;
+
+    public Utf8Decoding()
+    {
+        // Japanese Hiragana
+        var text = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん";
+        utf8bytes = Encoding.UTF8.GetBytes(text);
+        utf8length = utf8bytes.Length;
+        utf16length = text.Length;
+    }
+
+    [Benchmark]
+    public string UTF8GetString()
+    {
+        return Encoding.UTF8.GetString(utf8bytes);
+    }
+
+    [Benchmark]
+    public string Utf16LengthUtf8ToUtf16()
+    {
+        return string.Create(utf16length, utf8bytes, static (dest, source) =>
+        {
+            Utf8.ToUtf16(source, dest, out var read, out var written);
+        });
+    }
+}

--- a/sandbox/Benchmark/Program.cs
+++ b/sandbox/Benchmark/Program.cs
@@ -44,12 +44,14 @@ var config = ManualConfig.CreateMinimumViable()
 
 //BenchmarkRunner.Run<SerializeTest<JsonResponseModel>>(config, args);
 
-BenchmarkRunner.Run<Utf16VsUtf8>(config, args);
+//BenchmarkRunner.Run<Utf16VsUtf8>(config, args);
 
 //BenchmarkRunner.Run<SerializeTest<NeuralNetworkLayerModel>>(config, args);
 
 // BenchmarkRunner.Run<DeserializeTest<NeuralNetworkLayerModel>>(config, args);
-//BenchmarkRunner.Run<DeserializeTest<JsonResponseModel>>(config, args);
+
+
+BenchmarkRunner.Run<DeserializeTest<JsonResponseModel>>(config, args);
 
 
 //BenchmarkRunner.Run<GetLocalVsStaticField>(config, args);
@@ -67,7 +69,7 @@ var foo = new Utf8Decoding().Utf16LengthUtf8ToUtf16();
 Console.WriteLine(foo);
 
 Check<JsonResponseModel>();
-//Check<NeuralNetworkLayerModel>();
+Check<NeuralNetworkLayerModel>();
 
 void Check<T>()
     where T : IInitializable, IEquatable<T>, new()

--- a/sandbox/Benchmark/Program.cs
+++ b/sandbox/Benchmark/Program.cs
@@ -14,6 +14,8 @@ using MemoryPack;
 using MemoryPack.Formatters;
 using System.Reflection;
 
+#if !DEBUG
+
 var config = ManualConfig.CreateMinimumViable()
     .AddDiagnoser(MemoryDiagnoser.Default)
     .AddExporter(DefaultExporters.Plain)
@@ -22,6 +24,8 @@ var config = ManualConfig.CreateMinimumViable()
 
 //BenchmarkSwitcher.FromAssembly(Assembly.GetEntryAssembly()!).Run(args, config);
 
+
+//BenchmarkRunner.Run<Utf8Decoding>(config, args);
 
 //BenchmarkSwitcher.FromAssembly(Assembly.GetEntryAssembly()!).RunAllJoined(config);
 
@@ -40,6 +44,8 @@ var config = ManualConfig.CreateMinimumViable()
 
 //BenchmarkRunner.Run<SerializeTest<JsonResponseModel>>(config, args);
 
+BenchmarkRunner.Run<Utf16VsUtf8>(config, args);
+
 //BenchmarkRunner.Run<SerializeTest<NeuralNetworkLayerModel>>(config, args);
 
 // BenchmarkRunner.Run<DeserializeTest<NeuralNetworkLayerModel>>(config, args);
@@ -48,18 +54,19 @@ var config = ManualConfig.CreateMinimumViable()
 
 //BenchmarkRunner.Run<GetLocalVsStaticField>(config, args);
 
-BenchmarkSwitcher.FromTypes(new[]{
-    typeof(SerializeTest<>),
-    typeof(DeserializeTest<>) })
-    .RunAllJoined(config);
+//BenchmarkSwitcher.FromTypes(new[]{
+//    typeof(SerializeTest<>),
+//    typeof(DeserializeTest<>) })
+//    .RunAllJoined(config);
 
+#endif
 
 #if DEBUG
 
+var foo = new Utf8Decoding().Utf16LengthUtf8ToUtf16();
+Console.WriteLine(foo);
 
-
-
- Check<JsonResponseModel>();
+Check<JsonResponseModel>();
 //Check<NeuralNetworkLayerModel>();
 
 void Check<T>()

--- a/sandbox/SandboxConsoleApp/Program.cs
+++ b/sandbox/SandboxConsoleApp/Program.cs
@@ -20,10 +20,12 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml.Linq;
 
-var a = int.MaxValue;
-var b = ~a;
-Console.WriteLine(b);
 
+
+var bin = MemoryPackSerializer.Serialize("hogehoge");
+var takotako = MemoryPackSerializer.Deserialize<string>(bin);
+
+Console.WriteLine(takotako);
 
 // ---
 

--- a/sandbox/SandboxConsoleApp/Program.cs
+++ b/sandbox/SandboxConsoleApp/Program.cs
@@ -16,22 +16,40 @@ using System.IO.Compression;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml.Linq;
 
 
 
-var bin = MemoryPackSerializer.Serialize("hogehoge");
-var takotako = MemoryPackSerializer.Deserialize<string>(bin);
+//var bin = MemoryPackSerializer.Serialize("hogehoge");
+//var takotako = MemoryPackSerializer.Deserialize<string>(bin);
 
-Console.WriteLine(takotako);
+//Console.WriteLine(takotako);
 
 // ---
 
+var str = "あいうえおかきくけこさしすせそたちつてとなにぬねの";
+var bytes = Encoding.UTF8.GetBytes(str);
+
+var encoder = new BrotliEncoder(4, 22);
 
 
-//var encoder = new BrotliEncoder(4, 22);
+
+
+
+var dest = new byte[1024];
+
+//bytes = MemoryMarshal.AsBytes(str.AsSpan()).ToArray();
+
+encoder.Compress(bytes, dest, out var consumed, out var written, true);
+
+
+var foo = dest.AsSpan(0, written).ToArray();
+
+Console.WriteLine(bytes.Length);
+Console.WriteLine(foo.Length);
 
 //// new BrotliDecoder().Decompress(
 

--- a/src/MemoryPack.Core/Formatters/ImmutableCollectionFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/ImmutableCollectionFormatters.cs
@@ -144,7 +144,7 @@ namespace MemoryPack.Formatters
             var tempBuffer = ReusableLinkedArrayBufferWriterPool.Rent();
             try
             {
-                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer);
+                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer, writer.Options);
 
                 var count = 0;
                 var formatter = writer.GetFormatter<T?>();
@@ -233,7 +233,7 @@ namespace MemoryPack.Formatters
             var tempBuffer = ReusableLinkedArrayBufferWriterPool.Rent();
             try
             {
-                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer);
+                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer, writer.Options);
 
                 var count = 0;
                 var formatter = writer.GetFormatter<T?>();
@@ -596,7 +596,7 @@ namespace MemoryPack.Formatters
             var tempBuffer = ReusableLinkedArrayBufferWriterPool.Rent();
             try
             {
-                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer);
+                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer, writer.Options);
 
                 var count = 0;
                 var formatter = writer.GetFormatter<T?>();
@@ -685,7 +685,7 @@ namespace MemoryPack.Formatters
             var tempBuffer = ReusableLinkedArrayBufferWriterPool.Rent();
             try
             {
-                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer);
+                var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer, writer.Options);
 
                 var count = 0;
                 var formatter = writer.GetFormatter<T?>();

--- a/src/MemoryPack.Core/Formatters/InterfaceCollectionFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/InterfaceCollectionFormatters.cs
@@ -126,7 +126,7 @@ namespace MemoryPack.Formatters
                 var tempBuffer = ReusableLinkedArrayBufferWriterPool.Rent();
                 try
                 {
-                    var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer);
+                    var tempWriter = new MemoryPackWriter<ReusableLinkedArrayBufferWriter>(ref tempBuffer, writer.Options);
 
                     count = 0;
                     var formatter = writer.GetFormatter<T?>();

--- a/src/MemoryPack.Core/MemoryPackReader.cs
+++ b/src/MemoryPack.Core/MemoryPackReader.cs
@@ -1,9 +1,13 @@
 ﻿using System.Buffers;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Unicode;
 
 namespace MemoryPack;
 
+[StructLayout(LayoutKind.Auto)]
 public ref partial struct MemoryPackReader
 {
     ReadOnlySequence<byte> bufferSource;
@@ -199,6 +203,19 @@ public ref partial struct MemoryPackReader
             return "";
         }
 
+        if (length > 0)
+        {
+            return ReadUtf16(length);
+        }
+        else
+        {
+            return ReadUtf8(length);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    string ReadUtf16(int length)
+    {
         var byteCount = length * 2;
         ref var src = ref GetSpanReference(byteCount);
 
@@ -208,6 +225,48 @@ public ref partial struct MemoryPackReader
 
         return str;
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)] // non default, no inline
+    string ReadUtf8(int utf8Length)
+    {
+        // [utf8-length, utf16-length, utf8-value]
+        // already read utf8 length, but it is complement.
+
+        utf8Length = ~utf8Length;
+
+        // TODO:security
+
+        ref var spanRef = ref GetSpanReference(utf8Length + 4); // + read utf16 length
+
+        string str;
+        var utf16Length = Unsafe.ReadUnaligned<int>(ref spanRef);
+        if (utf16Length <= 0)
+        {
+            var src = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref spanRef, 4), utf8Length);
+            str = Encoding.UTF8.GetString(src);
+        }
+        else
+        {
+            unsafe
+            {
+                fixed (byte* p = &Unsafe.Add(ref spanRef, 4))
+                {
+                    str = string.Create(utf16Length, ((IntPtr)p, utf8Length), static (dest, state) =>
+                    {
+                        var src = MemoryMarshal.CreateSpan(ref Unsafe.AsRef<byte>((byte*)state.Item1), state.Item2);
+                        var status = Utf8.ToUtf16(src, dest, out var bytesRead, out var charsWritten);
+                        // TODO: throw when status failed
+                    });
+                }
+            }
+        }
+
+        Advance(utf8Length + 4);
+
+        return str;
+    }
+
+    delegate void ReadOnlySpanAction(Span<char> span, ReadOnlySpan<byte> arg);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ReadPackable<T>(scoped ref T? value)

--- a/src/MemoryPack.Core/MemoryPackSerializationException.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializationException.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MemoryPack;
 
@@ -102,5 +103,11 @@ public class MemoryPackSerializationException : Exception
     public static void ThrowDeserializeObjectIsNull(string target)
     {
         throw new MemoryPackSerializationException($"Deserialized {target} is null.");
+    }
+
+    [DoesNotReturn]
+    public static void ThrowFailedEncoding(OperationStatus status)
+    {
+        throw new MemoryPackSerializationException($"Failed Utf8 encoding/decoding process, status: {status}.");
     }
 }

--- a/src/MemoryPack.Core/MemoryPackSerializeOptions.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializeOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace MemoryPack;
+
+public record MemoryPackSerializeOptions
+{
+    public static MemoryPackSerializeOptions Default = new MemoryPackSerializeOptions { StringEncoding = StringEncoding.Utf16 };
+    public static MemoryPackSerializeOptions Utf8 = Default with { StringEncoding = StringEncoding.Utf8 };
+
+    public StringEncoding StringEncoding { get; init; }
+}
+
+public enum StringEncoding : byte
+{
+    Utf16,
+    Utf8,
+}

--- a/src/MemoryPack.Core/MemoryPackSerializeOptions.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializeOptions.cs
@@ -2,8 +2,11 @@
 
 public record MemoryPackSerializeOptions
 {
-    public static MemoryPackSerializeOptions Default = new MemoryPackSerializeOptions { StringEncoding = StringEncoding.Utf16 };
-    public static MemoryPackSerializeOptions Utf8 = Default with { StringEncoding = StringEncoding.Utf8 };
+    // Default is Utf8
+    public static readonly MemoryPackSerializeOptions Default = new MemoryPackSerializeOptions { StringEncoding = StringEncoding.Utf8 };
+
+    public static readonly MemoryPackSerializeOptions Utf8 = Default with { StringEncoding = StringEncoding.Utf8 };
+    public static readonly MemoryPackSerializeOptions Utf16 = Default with { StringEncoding = StringEncoding.Utf16 };
 
     public StringEncoding StringEncoding { get; init; }
 }

--- a/src/MemoryPack.Core/MemoryPackWriter.cs
+++ b/src/MemoryPack.Core/MemoryPackWriter.cs
@@ -1,9 +1,12 @@
 ﻿using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Unicode;
 
 namespace MemoryPack;
 
+[StructLayout(LayoutKind.Auto)]
 public ref partial struct MemoryPackWriter<TBufferWriter>
     where TBufferWriter : IBufferWriter<byte>
 {
@@ -15,10 +18,13 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
     int advancedCount;
     int depth; // check recursive serialize
     int writtenCount;
+    readonly bool serializeStringAsUtf8;
+    readonly MemoryPackSerializeOptions options;
 
     public int WrittenCount => writtenCount;
+    public MemoryPackSerializeOptions Options => options;
 
-    public MemoryPackWriter(ref TBufferWriter writer)
+    public MemoryPackWriter(ref TBufferWriter writer, MemoryPackSerializeOptions options)
     {
         this.bufferWriter = ref writer;
         this.bufferReference = ref Unsafe.NullRef<byte>();
@@ -26,10 +32,12 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         this.advancedCount = 0;
         this.writtenCount = 0;
         this.depth = 0;
+        this.serializeStringAsUtf8 = options.StringEncoding == StringEncoding.Utf8;
+        this.options = options;
     }
 
     // optimized ctor, avoid first GetSpan call if we can.
-    public MemoryPackWriter(ref TBufferWriter writer, byte[] firstBufferOfWriter)
+    public MemoryPackWriter(ref TBufferWriter writer, byte[] firstBufferOfWriter, MemoryPackSerializeOptions options)
     {
         this.bufferWriter = ref writer;
         this.bufferReference = ref MemoryMarshal.GetArrayDataReference(firstBufferOfWriter);
@@ -37,9 +45,11 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         this.advancedCount = 0;
         this.writtenCount = 0;
         this.depth = 0;
+        this.serializeStringAsUtf8 = options.StringEncoding == StringEncoding.Utf8;
+        this.options = options;
     }
 
-    public MemoryPackWriter(ref TBufferWriter writer, Span<byte> firstBufferOfWriter)
+    public MemoryPackWriter(ref TBufferWriter writer, Span<byte> firstBufferOfWriter, MemoryPackSerializeOptions options)
     {
         this.bufferWriter = ref writer;
         this.bufferReference = ref MemoryMarshal.GetReference(firstBufferOfWriter);
@@ -47,6 +57,8 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         this.advancedCount = 0;
         this.writtenCount = 0;
         this.depth = 0;
+        this.serializeStringAsUtf8 = options.StringEncoding == StringEncoding.Utf8;
+        this.options = options;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -165,18 +177,62 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
             return;
         }
 
+        if (value.Length == 0)
+        {
+            Unsafe.WriteUnaligned(ref GetSpanReference(4), 0);
+            Advance(4);
+            return;
+        }
+
+        if (serializeStringAsUtf8)
+        {
+            WriteUtf8(value);
+        }
+        else
+        {
+            WriteUtf16(value);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    void WriteUtf16(string value)
+    {
         var copyByteCount = value.Length * 2;
 
         ref var dest = ref GetSpanReference(copyByteCount + 4);
         Unsafe.WriteUnaligned(ref dest, value.Length);
 
-        if (copyByteCount > 0)
-        {
-            ref var src = ref Unsafe.As<char, byte>(ref Unsafe.AsRef(value.GetPinnableReference()));
-            Unsafe.CopyBlockUnaligned(ref Unsafe.Add(ref dest, 4), ref src, (uint)copyByteCount);
-        }
+        ref var src = ref Unsafe.As<char, byte>(ref Unsafe.AsRef(value.GetPinnableReference()));
+        Unsafe.CopyBlockUnaligned(ref Unsafe.Add(ref dest, 4), ref src, (uint)copyByteCount);
 
         Advance(copyByteCount + 4);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)] // non default, no inline
+    void WriteUtf8(string value)
+    {
+        // [utf8-length, utf16-length, utf8-value]
+
+        var source = value.AsSpan();
+
+        // UTF8.GetMaxByteCount -> (length + 1) * 3
+        var maxByteCount = (source.Length + 1) * 3;
+
+        ref var destPointer = ref GetSpanReference(maxByteCount + 8); // header
+
+        // write utf8-length is final
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destPointer, 4), source.Length);
+
+        var dest = MemoryMarshal.CreateSpan(ref Unsafe.Add(ref destPointer, 8), maxByteCount);
+        var status = Utf8.FromUtf16(source, dest, out var _, out var bytesWritten);
+        if (status != OperationStatus.Done)
+        {
+            // TODO: throw when write failed.
+        }
+
+        // write written utf8-length in header, that is ~length
+        Unsafe.WriteUnaligned(ref destPointer, ~bytesWritten);
+        Advance(bytesWritten + 8); // + header
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/MemoryPack.Tests/StringTest.cs
+++ b/tests/MemoryPack.Tests/StringTest.cs
@@ -1,0 +1,46 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace MemoryPack.Tests;
+
+public class StringTest
+{
+    [Fact]
+    public void Utf16()
+    {
+        var text = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほわをん";
+
+        var bin = MemoryPackSerializer.Serialize(text, MemoryPackSerializeOptions.Utf16);
+        var newText = MemoryPackSerializer.Deserialize<string>(bin);
+
+        text.Should().Be(newText);
+    }
+
+    [Fact]
+    public void Utf8()
+    {
+        var text = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほわをん";
+
+        var bin = MemoryPackSerializer.Serialize(text, MemoryPackSerializeOptions.Utf8);
+        var newText = MemoryPackSerializer.Deserialize<string>(bin);
+
+        text.Should().Be(newText);
+    }
+
+    [Fact]
+    public void MalformedUtf8()
+    {
+        var text = "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほわをん";
+
+        var bin = MemoryPackSerializer.Serialize(text, MemoryPackSerializeOptions.Utf8);
+
+        ref var head = ref MemoryMarshal.GetArrayDataReference(bin);
+
+        // [utf8-length, utf16-length, utf8-value]
+        // change utf16-length
+
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref head, 4), 9999);
+
+        Assert.Throws<MemoryPackSerializationException>(()=> MemoryPackSerializer.Deserialize<string>(bin));
+    }
+}

--- a/tests/MemoryPack.Tests/WriterTest.cs
+++ b/tests/MemoryPack.Tests/WriterTest.cs
@@ -10,7 +10,7 @@ public class WriterTest
     {
         var buffer = new SpanControlWriter();
 
-        var writer = new MemoryPackWriter<SpanControlWriter>(ref buffer);
+        var writer = new MemoryPackWriter<SpanControlWriter>(ref buffer, MemoryPackSerializeOptions.Default);
 
         buffer.ProvideSpanLength = 5;
 
@@ -50,7 +50,7 @@ public class WriterTest
         var buffer = new ArrayBufferWriter<byte>();
 
         {
-            var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref buffer);
+            var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref buffer, MemoryPackSerializeOptions.Default);
 
             writer.WriteNullObjectHeader();
             writer.Flush();
@@ -60,7 +60,7 @@ public class WriterTest
         }
         for (var i = 0; i < 250; i++)
         {
-            var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref buffer);
+            var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref buffer, MemoryPackSerializeOptions.Default);
             writer.WriteObjectHeader((byte)i);
             writer.Flush();
 
@@ -71,7 +71,7 @@ public class WriterTest
         for (byte i = MemoryPackCode.Reserved1; i <= MemoryPackCode.NullObject; i++)
         {
             if (i == 0) break;
-            var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref buffer);
+            var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref buffer, MemoryPackSerializeOptions.Default);
             var error = false;
             try
             {


### PR DESCRIPTION
#13

new wire format String introduced.
using MemoryPackSerializeOptions.Utf8 to Serialize methods.
deserializer can detect which encoding used, we can deserialize both utf16 and utf8.