### PR TITLE
Using ref var foreach for CollectionsMarshal.AsSpan

### DIFF
--- a/src/MemoryPack.Core/Internal/ReusableLinkedArrayBufferWriter.cs
+++ b/src/MemoryPack.Core/Internal/ReusableLinkedArrayBufferWriter.cs
@@ -136,7 +136,7 @@ internal sealed class ReusableLinkedArrayBufferWriter : IBufferWriter<byte>
 
         if (buffers.Count > 0)
         {
-            foreach (var item in CollectionsMarshal.AsSpan(buffers))
+            foreach (ref var item in CollectionsMarshal.AsSpan(buffers))
             {
                 item.WrittenBuffer.CopyTo(dest);
                 dest = dest.Slice(item.WrittenCount);
@@ -168,7 +168,7 @@ internal sealed class ReusableLinkedArrayBufferWriter : IBufferWriter<byte>
 
         if (buffers.Count > 0)
         {
-            foreach (var item in CollectionsMarshal.AsSpan(buffers))
+            foreach (ref var item in CollectionsMarshal.AsSpan(buffers))
             {
                 ref var spanRef = ref writer.GetSpanReference(item.WrittenCount);
                 item.WrittenBuffer.CopyTo(MemoryMarshal.CreateSpan(ref spanRef, item.WrittenCount));
@@ -235,7 +235,7 @@ internal sealed class ReusableLinkedArrayBufferWriter : IBufferWriter<byte>
     public void Reset()
     {
         if (totalWritten == 0) return;
-        foreach (var item in CollectionsMarshal.AsSpan(buffers))
+        foreach (ref var item in CollectionsMarshal.AsSpan(buffers))
         {
             item.Clear();
         }


### PR DESCRIPTION
Micro optimization based on following blog article: https://blog.marcgravell.com/2022/05/unusual-optimizations-ref-foreach-and.html

>Our use of ref var tmp with foreach here means that the L-value (tmp) is a managed pointer to the data - not the data itself; we have avoided copying the overweight value-type, and called the method in-place.

[SharpLab](https://sharplab.io/#v2:C4LglgNgPgAgTARgLACgYAYAEMEBYDcqG2CAdAEoCuAdsGALYCmpAkrYwE4D2ADgMqcAbmADGjAM6EURAMzY4mAMKoA3qkwaSANkxhamAGJcOAUQCGIgBYAKADJhxwADx8uTPsA6URwAHyZxN0Z7RwBKdU01FE0Y3X1gLmAzCEwAXkx0KVjNADNjRgtLTGtBMw5MYHoeOICgkOBw6OzMKObYhKSUgGp0yp5SVyYANWTKRizmgF8I7JgAdgrE5ImNaaaNGe044CUAWSNTQpGOOwdnQcYPLx9/QKZ6xpjW5r0djuS0jJXYvI4Cq2KpXKfRqii4EAgjB8YC41HEuzK4ksyVIAEFxHweGZqNY7sEzqFHs1nm0NO9ur0qgMgiMIGNvjE1m15otOt8mZpNjgdK89gdzFZyIwcsdTo4XEErt4/LV7gTNiTYrzyZ9MpsYr9/kVrH8cpggRUqqDwZDobD4YjkRA0RisTi8Q8idlFW0VT1Df0LrT6erNBzZgtyezUP7tpxqB8/mYACawiAATwCnmlmAuUp8Ct9GhgcjTyZ81l5eO9jCdsRdzS9o0Yn2L1YZfqz2DkvKrdJrKkwAHNGMB8JhQ5MgA==)

![image](https://user-images.githubusercontent.com/39406255/194210440-ff1e19c5-f96a-4c1e-879b-2c7e73cb2a10.png)
