### PR TITLE
feat: add Unity CI

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -49,13 +49,9 @@ jobs:
           buildMethod: UnitTestBuilder.BuildUnitTest
           customParameters: /headless /ScriptBackend mono
           versioning: None
-      - uses: actions/upload-artifact@v2
-        with:
-          name: test
-          path: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test
-          if-no-files-found: error
-      - name: Execute UnitTest
-        run: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test -batchmode
+      # Unity 2021.2 and above changed Headless mode. It seems require Dedicated Server currently and investigating alternative api to enable batch mode.
+      # - name: Execute UnitTest
+      #   run: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test -batchmode
 
       # Execute scripts: Export Package
       #  /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -20,6 +20,57 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
-          include-prerelease: 'true'
+          include-prerelease: "true"
       - run: dotnet build -c Debug
       - run: dotnet test -c Debug --no-build
+
+  build-unity:
+    if: "((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
+    strategy:
+      matrix:
+        unity: ["2021.3.11f1"]
+        include:
+          - unity: 2021.3.11f1
+            license: UNITY_LICENSE_2021
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      # Execute scripts: RuntimeUnitTestToolkit
+      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend mono /BuildTarget StandaloneLinux64
+      - name: Build UnitTest(Linux64, mono)
+        uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          projectPath: src/MemoryPack.Unity
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: UnitTestBuilder.BuildUnitTest
+          customParameters: /headless /ScriptBackend mono
+          versioning: None
+      - name: Execute UnitTest
+        run: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test
+
+      # Execute scripts: Export Package
+      #  /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+      - name: Export unitypackage
+        uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          projectPath: src/MemoryPack.Unity
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
+
+      - uses: Cysharp/Actions/.github/actions/check-metas@main # check meta files
+        with:
+          directory: src/MemoryPack.Unity
+
+      # Store artifacts.
+      - uses: actions/upload-artifact@v2
+        with:
+          name: MemoryPack.${{ matrix.unity }}.unitypackage.zip
+          path: ./src/MemoryPack.Unity/*.unitypackage

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -49,6 +49,11 @@ jobs:
           buildMethod: UnitTestBuilder.BuildUnitTest
           customParameters: /headless /ScriptBackend mono
           versioning: None
+      - uses: actions/upload-artifact@v2
+        with:
+          name: test
+          path: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test
+          if-no-files-found: error
       - name: Execute UnitTest
         run: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test
 

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -55,7 +55,7 @@ jobs:
           path: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test
           if-no-files-found: error
       - name: Execute UnitTest
-        run: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test
+        run: ./src/MemoryPack.Unity/bin/UnitTest/StandaloneLinux64_Mono2x/test -batchmode
 
       # Execute scripts: Export Package
       #  /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,10 +12,11 @@ on:
         default: "false"
 
 env:
-  GIT_TAG: ${{ github.event.inputs.tag }}
-  DRY_RUN: ${{ github.event.inputs.dry-run }}
+  GIT_TAG: ${{ inputs.tag }}
+  DRY_RUN: ${{ inputs.dry-run }}
 
 jobs:
+  # dotnet
   build-dotnet:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -26,7 +27,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
-          include-prerelease: 'true'
+          include-prerelease: "true"
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}
       - run: dotnet test -c Release --no-build
@@ -36,9 +37,56 @@ jobs:
           name: nuget
           path: ./publish
 
+  # unity
+  update-packagejson:
+    uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
+    with:
+      file-path: ./src/MemoryPack.Unity/Assets/Plugins/MemoryPack/package.json
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
+
+  build-unity:
+    needs: [update-packagejson]
+    strategy:
+      matrix:
+        unity: ["2021.3.11f1"]
+        include:
+          - unity: 2021.3.11f1
+            license: UNITY_LICENSE_2021
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - run: echo ${{ needs.update-packagejson.outputs.sha }}
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.update-packagejson.outputs.sha }}
+      # Execute scripts: Export Package
+      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+      - name: Export unitypackage
+        uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          projectPath: src/MemoryPack.Unity
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
+      # check meta files
+      - uses: Cysharp/Actions/.github/actions/check-metas@main
+        with:
+          directory: src/MemoryPack.Unity
+      # Store artifacts.
+      - uses: actions/upload-artifact@v2
+        with:
+          name: MemoryPack.Unity.${{ env.GIT_TAG }}.unitypackage
+          path: ./src/MemoryPack.Unity/MemoryPack*.${{ env.GIT_TAG }}.unitypackage
+          if-no-files-found: error
+
+  # release
   create-release:
-    if: github.event.inputs.dry-run == 'false'
-    needs: [build-dotnet]
+    if: inputs.dry-run == 'false'
+    needs: [update-packagejson, build-dotnet, build-unity]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -48,7 +96,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
-          include-prerelease: 'true'
+          include-prerelease: "true"
       - uses: actions/checkout@v3
       - name: tag
         run: git tag ${{ env.GIT_TAG }}
@@ -72,3 +120,10 @@ jobs:
       - uses: actions/download-artifact@v2
       # Upload to NuGet
       - run: dotnet nuget push "./nuget/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
+
+  cleanup:
+    if: needs.update-packagejson.outputs.is-branch-created == 'true'
+    needs: [update-packagejson, build-unity]
+    uses: Cysharp/Actions/.github/workflows/clean-packagejson-branch.yaml@main
+    with:
+      branch: ${{ needs.update-packagejson.outputs.branch-name }}


### PR DESCRIPTION
## tl;dr;

Enable Unity build on GitHub Actions.

## RuntimeUnitTestToolkit

Since 2021.2, `BuildOptions.EnableHeadlessMode` is obsoleted and won't work anymore, even set true.
Due to this Unity API change, UnitTest is currently disabled.

Following to obsolete message, it says [Use StandaloneBuildSubtarget.Server instead](https://github.com/Unity-Technologies/UnityCsReference/blob/6d3b44c3a737075fb8a31700450b2ee557a49d82/Editor/Mono/BuildPipeline.bindings.cs#L77) however it require dedicated server even we only need batch mode.

Currently searching alternative way, so let's disable Unit Test on Unity for a while.