### PR TITLE
Add IMemoryOwner<T> formatter

### DIFF
--- a/src/MemoryPack.Core/Formatters/ArrayFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/ArrayFormatters.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 // ReadOnlyMemory
 // ArraySegment
 // ReadOnlySequence
+// IMemoryOwner
 
 namespace MemoryPack
 {
@@ -24,6 +25,7 @@ namespace MemoryPack
             { typeof(Memory<>), typeof(MemoryFormatter<>) },
             { typeof(ReadOnlyMemory<>), typeof(ReadOnlyMemoryFormatter<>) },
             { typeof(ReadOnlySequence<>), typeof(ReadOnlySequenceFormatter<>) },
+            { typeof(IMemoryOwner<>), typeof(IMemoryOwnerFormatter<>) },
         };
     }
 }
@@ -152,6 +154,46 @@ namespace MemoryPack.Formatters
         {
             var array = reader.ReadArray<T>();
             value = (array == null) ? default : new ReadOnlySequence<T?>(array);
+        }
+    }
+
+    [Preserve]
+    public sealed class IMemoryOwnerFormatter<T> : MemoryPackFormatter<IMemoryOwner<T?>?>
+    {
+        [Preserve]
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref IMemoryOwner<T?>? value)
+        {
+            if (value == null)
+            {
+                writer.WriteNullObjectHeader();
+                return;
+            }
+
+            writer.WriteObjectHeader(1);
+            writer.WriteSpan(value.Memory.Span);
+        }
+
+        [Preserve]
+        public override void Deserialize(ref MemoryPackReader reader, scoped ref IMemoryOwner<T?>? value)
+        {
+            if (!reader.TryReadObjectHeader(out var count))
+            {
+                value = null;
+                return;
+            }
+
+            if (count != 1) MemoryPackSerializationException.ThrowInvalidPropertyCount(1, count);
+
+            if (!reader.TryReadCollectionHeader(out var length))
+            {
+                value = null;
+                return;
+            }
+
+            value = MemoryPool<T?>.Shared.Rent(length);
+            Span<T?> refSpan = value.Memory.Span;
+
+            reader.ReadSpanWithoutReadLengthHeader(length, ref refSpan);
         }
     }
 }


### PR DESCRIPTION
Adds support for an IMemoryOwner<T> formatter.

I tried to match the syntax of the other formatters so I've based it off MemoryFormatter<T> and LazyFormatter<T>.
Let me know if this is correct.