### PR TITLE
Deserialize array from ArrayPool

### DIFF
--- a/sandbox/SandboxConsoleApp/Program.cs
+++ b/sandbox/SandboxConsoleApp/Program.cs
@@ -48,9 +48,6 @@ foreach (var item in new[] { str1, str2, str3 })
 
 
 
-
-
-
 // ---
 
 static byte[] Compress(ReadOnlySpan<byte> source)
@@ -80,6 +77,28 @@ public partial class IntClass2
     public int Value { get; set; }
 }
 
+
+
+[MemoryPackable]
+public partial struct BrotliValue<T>
+{
+    public long Value { get; set; }
+}
+
+
+public partial class MyClass : IDisposable
+{
+    [ArrayPoolMemoryFormatter<int>]
+    public Memory<int> LargeArray { get; }
+
+    public void Dispose()
+    {
+        if (MemoryMarshal.TryGetArray<int>(LargeArray, out var segment))
+        {
+            ArrayPool<int>.Shared.Return(segment.Array!);
+        }
+    }
+}
 
 
 

--- a/sandbox/SandboxWebApp/Program.cs
+++ b/sandbox/SandboxWebApp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using MemoryPack;
 using MemoryPack.AspNetCoreMvcFormatter;
+using System.Diagnostics;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/MemoryPack.Core/CustomFormatterAttributes.cs
+++ b/src/MemoryPack.Core/CustomFormatterAttributes.cs
@@ -102,11 +102,21 @@ public sealed class BrotliStringFormatterAttribute : MemoryPackCustomFormatterAt
     }
 }
 
-public sealed class ArrayPoolMemoryFormatterAttribute<T> : MemoryPackCustomFormatterAttribute<ArrayPoolMemoryFormatter<T?>, Memory<T?>>
+public sealed class MemoryPoolFormatterAttribute<T> : MemoryPackCustomFormatterAttribute<MemoryPoolFormatter<T>, Memory<T?>>
 {
-    static readonly ArrayPoolMemoryFormatter<T> formatter = new ArrayPoolMemoryFormatter<T>();
+    static readonly MemoryPoolFormatter<T> formatter = new MemoryPoolFormatter<T>();
 
-    public override ArrayPoolMemoryFormatter<T> GetFormatter()
+    public override MemoryPoolFormatter<T> GetFormatter()
+    {
+        return formatter;
+    }
+}
+
+public sealed class ReadOnlyMemoryPoolFormatterAttribute<T> : MemoryPackCustomFormatterAttribute<ReadOnlyMemoryPoolFormatter<T>, ReadOnlyMemory<T?>>
+{
+    static readonly ReadOnlyMemoryPoolFormatter<T> formatter = new ReadOnlyMemoryPoolFormatter<T>();
+
+    public override ReadOnlyMemoryPoolFormatter<T> GetFormatter()
     {
         return formatter;
     }

--- a/src/MemoryPack.Core/CustomFormatterAttributes.cs
+++ b/src/MemoryPack.Core/CustomFormatterAttributes.cs
@@ -102,4 +102,14 @@ public sealed class BrotliStringFormatterAttribute : MemoryPackCustomFormatterAt
     }
 }
 
+public sealed class ArrayPoolMemoryFormatterAttribute<T> : MemoryPackCustomFormatterAttribute<ArrayPoolMemoryFormatter<T?>, Memory<T?>>
+{
+    static readonly ArrayPoolMemoryFormatter<T> formatter = new ArrayPoolMemoryFormatter<T>();
+
+    public override ArrayPoolMemoryFormatter<T> GetFormatter()
+    {
+        return formatter;
+    }
+}
+
 #endif

--- a/src/MemoryPack.Core/Formatters/ArrayFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/ArrayFormatters.cs
@@ -154,4 +154,35 @@ namespace MemoryPack.Formatters
             value = (array == null) ? default : new ReadOnlySequence<T?>(array);
         }
     }
+
+    [Preserve]
+    public sealed class ArrayPoolMemoryFormatter<T> : MemoryPackFormatter<Memory<T?>>
+    {
+        [Preserve]
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref Memory<T?> value)
+        {
+            writer.WriteSpan(value.Span);
+        }
+
+        [Preserve]
+        public override void Deserialize(ref MemoryPackReader reader, scoped ref Memory<T?> value)
+        {
+            if (!reader.TryReadCollectionHeader(out var length))
+            {
+                value = null;
+                return;
+            }
+
+            if (length == 0)
+            {
+                value = Memory<T?>.Empty;
+                return;
+            }
+
+            var memory = ArrayPool<T?>.Shared.Rent(length).AsMemory(0, length);
+            var span = memory.Span;
+            reader.ReadSpanWithoutReadLengthHeader(length, ref span);
+            value = memory;
+        }
+    }
 }

--- a/src/MemoryPack.Core/Formatters/ArrayFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/ArrayFormatters.cs
@@ -156,7 +156,7 @@ namespace MemoryPack.Formatters
     }
 
     [Preserve]
-    public sealed class ArrayPoolMemoryFormatter<T> : MemoryPackFormatter<Memory<T?>>
+    public sealed class MemoryPoolFormatter<T> : MemoryPackFormatter<Memory<T?>>
     {
         [Preserve]
         public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref Memory<T?> value)
@@ -166,6 +166,37 @@ namespace MemoryPack.Formatters
 
         [Preserve]
         public override void Deserialize(ref MemoryPackReader reader, scoped ref Memory<T?> value)
+        {
+            if (!reader.TryReadCollectionHeader(out var length))
+            {
+                value = null;
+                return;
+            }
+
+            if (length == 0)
+            {
+                value = Memory<T?>.Empty;
+                return;
+            }
+
+            var memory = ArrayPool<T?>.Shared.Rent(length).AsMemory(0, length);
+            var span = memory.Span;
+            reader.ReadSpanWithoutReadLengthHeader(length, ref span);
+            value = memory;
+        }
+    }
+
+    [Preserve]
+    public sealed class ReadOnlyMemoryPoolFormatter<T> : MemoryPackFormatter<ReadOnlyMemory<T?>>
+    {
+        [Preserve]
+        public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref ReadOnlyMemory<T?> value)
+        {
+            writer.WriteSpan(value.Span);
+        }
+
+        [Preserve]
+        public override void Deserialize(ref MemoryPackReader reader, scoped ref ReadOnlyMemory<T?> value)
         {
             if (!reader.TryReadCollectionHeader(out var length))
             {

--- a/src/MemoryPack.Unity/Assets/Plugins/MemoryPack/Runtime/MemoryPack.Core/CustomFormatterAttributes.cs
+++ b/src/MemoryPack.Unity/Assets/Plugins/MemoryPack/Runtime/MemoryPack.Core/CustomFormatterAttributes.cs
@@ -111,6 +111,26 @@ public sealed class BrotliStringFormatterAttribute : MemoryPackCustomFormatterAt
     }
 }
 
+public sealed class MemoryPoolFormatterAttribute<T> : MemoryPackCustomFormatterAttribute<MemoryPoolFormatter<T>, Memory<T?>>
+{
+    static readonly MemoryPoolFormatter<T> formatter = new MemoryPoolFormatter<T>();
+
+    public override MemoryPoolFormatter<T> GetFormatter()
+    {
+        return formatter;
+    }
+}
+
+public sealed class ReadOnlyMemoryPoolFormatterAttribute<T> : MemoryPackCustomFormatterAttribute<ReadOnlyMemoryPoolFormatter<T>, ReadOnlyMemory<T?>>
+{
+    static readonly ReadOnlyMemoryPoolFormatter<T> formatter = new ReadOnlyMemoryPoolFormatter<T>();
+
+    public override ReadOnlyMemoryPoolFormatter<T> GetFormatter()
+    {
+        return formatter;
+    }
+}
+
 #endif
 
 }

--- a/src/MemoryPack.Unity/Assets/Plugins/MemoryPack/Runtime/MemoryPack.Core/Formatters/ArrayFormatters.cs
+++ b/src/MemoryPack.Unity/Assets/Plugins/MemoryPack/Runtime/MemoryPack.Core/Formatters/ArrayFormatters.cs
@@ -163,4 +163,66 @@ namespace MemoryPack.Formatters
             value = (array == null) ? default : new ReadOnlySequence<T?>(array);
         }
     }
+
+    [Preserve]
+    public sealed class MemoryPoolFormatter<T> : MemoryPackFormatter<Memory<T?>>
+    {
+        [Preserve]
+        public override void Serialize(ref MemoryPackWriter writer, ref Memory<T?> value)
+        {
+            writer.WriteSpan(value.Span);
+        }
+
+        [Preserve]
+        public override void Deserialize(ref MemoryPackReader reader, ref Memory<T?> value)
+        {
+            if (!reader.TryReadCollectionHeader(out var length))
+            {
+                value = null;
+                return;
+            }
+
+            if (length == 0)
+            {
+                value = Memory<T?>.Empty;
+                return;
+            }
+
+            var memory = ArrayPool<T?>.Shared.Rent(length).AsMemory(0, length);
+            var span = memory.Span;
+            reader.ReadSpanWithoutReadLengthHeader(length, ref span);
+            value = memory;
+        }
+    }
+
+    [Preserve]
+    public sealed class ReadOnlyMemoryPoolFormatter<T> : MemoryPackFormatter<ReadOnlyMemory<T?>>
+    {
+        [Preserve]
+        public override void Serialize(ref MemoryPackWriter writer, ref ReadOnlyMemory<T?> value)
+        {
+            writer.WriteSpan(value.Span);
+        }
+
+        [Preserve]
+        public override void Deserialize(ref MemoryPackReader reader, ref ReadOnlyMemory<T?> value)
+        {
+            if (!reader.TryReadCollectionHeader(out var length))
+            {
+                value = null;
+                return;
+            }
+
+            if (length == 0)
+            {
+                value = Memory<T?>.Empty;
+                return;
+            }
+
+            var memory = ArrayPool<T?>.Shared.Rent(length).AsMemory(0, length);
+            var span = memory.Span;
+            reader.ReadSpanWithoutReadLengthHeader(length, ref span);
+            value = memory;
+        }
+    }
 }

--- a/src/MemoryPack.Unity/UserSettings/Layouts/default-2021.dwlt
+++ b/src/MemoryPack.Unity/UserSettings/Layouts/default-2021.dwlt
@@ -97,7 +97,7 @@ MonoBehaviour:
   m_MinSize: {x: 310, y: 221}
   m_MaxSize: {x: 4000, y: 4021}
   vertical: 0
-  controlID: 251
+  controlID: 51
 --- !u!114 &5
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -175,7 +175,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 300}
   m_MaxSize: {x: 24288, y: 24288}
   vertical: 0
-  controlID: 244
+  controlID: 145
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -324,7 +324,7 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 300}
   m_MaxSize: {x: 8096, y: 24288}
   vertical: 1
-  controlID: 189
+  controlID: 17
 --- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -462,7 +462,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 38600000
     m_LastClickedID: 24632
-    m_ExpandedIDs: 00000000385f000000ca9a3bffffff7f
+    m_ExpandedIDs: 0000000052600000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -490,7 +490,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: ffffffff00000000385f000000ca9a3bffffff7f
+    m_ExpandedIDs: ffffffff0000000052600000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -620,7 +620,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: a4faffff
+      m_ExpandedIDs: 18fbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 

--- a/tests/MemoryPack.Tests/CustomFormatterTest.cs
+++ b/tests/MemoryPack.Tests/CustomFormatterTest.cs
@@ -2,8 +2,14 @@
 
 using MemoryPack.Tests.Models;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -43,4 +49,107 @@ public class CustomFormatterTest
         v2.Prop1.Should().Be(value.Prop1);
         v2.Field1.Should().Be(value.Field1);
     }
+
+#if NET7_0_OR_GREATER
+
+    [Fact]
+    public void Pool()
+    {
+        var forPool = new MemoryPoolModel(
+            new[] { 1, 10, 100, 100, 10000 },
+            Encoding.UTF8.GetBytes("あいうえおかきくけこさしすせそ"),
+            new[] { "aaa", "bbb", "DDDDDDDDDDDDDD", "あいうえおか" },
+            new[] { new StdData { MyProperty = 10 }, new StdData { MyProperty = 99 } }
+        );
+
+        var bin = MemoryPackSerializer.Serialize(forPool);
+        var v2 = MemoryPackSerializer.Deserialize<MemoryPoolModel>(bin);
+
+        //v2.Pool1.Length
+        MemoryMarshal.TryGetArray<int>(v2.Pool1, out var seg1).Should().BeTrue();
+        MemoryMarshal.TryGetArray<byte>(v2.Pool2, out var seg2).Should().BeTrue();
+        MemoryMarshal.TryGetArray(v2.Pool3, out var seg3).Should().BeTrue();
+        MemoryMarshal.TryGetArray(v2.Pool4, out var seg4).Should().BeTrue();
+
+        seg1.Array.Length.Should().Be(PoolSize(forPool.Pool1.Length));
+        seg2.Array.Length.Should().Be(PoolSize(forPool.Pool2.Length));
+        seg3.Array.Length.Should().Be(PoolSize(forPool.Pool3.Length));
+        seg4.Array.Length.Should().Be(PoolSize(forPool.Pool4.Length));
+
+        v2.Pool1.ToArray().Should().Equal(forPool.Pool1.ToArray());
+        v2.Pool2.ToArray().Should().Equal(forPool.Pool2.ToArray());
+        v2.Pool3.ToArray().Should().Equal(forPool.Pool3.ToArray());
+
+        v2.Pool4.Span[0].MyProperty.Should().Be(forPool.Pool4.Span[0].MyProperty);
+        v2.Pool4.Span[1].MyProperty.Should().Be(forPool.Pool4.Span[1].MyProperty);
+
+        v2.Dispose();
+        v2.Dispose();
+    }
+
+    int PoolSize(int size)
+    {
+        size = BitOperations.Log2((uint)size - 1 | 15) - 3;
+        return 16 << size;
+    }
+
+#endif
 }
+#if NET7_0_OR_GREATER
+
+[MemoryPackable]
+public partial class MemoryPoolModel : IDisposable
+{
+    [MemoryPoolFormatter<int>]
+    public Memory<int> Pool1 { get; private set; }
+    [MemoryPoolFormatter<byte>]
+    public Memory<byte> Pool2 { get; private set; }
+    [ReadOnlyMemoryPoolFormatter<string>]
+    public ReadOnlyMemory<string> Pool3 { get; private set; }
+    [ReadOnlyMemoryPoolFormatter<StdData>]
+    public ReadOnlyMemory<StdData> Pool4 { get; private set; }
+
+    bool usePool;
+
+    public MemoryPoolModel(Memory<int> pool1, Memory<byte> pool2, ReadOnlyMemory<string> pool3, ReadOnlyMemory<StdData> pool4)
+    {
+        Pool1 = pool1;
+        Pool2 = pool2;
+        Pool3 = pool3;
+        Pool4 = pool4;
+    }
+
+    [MemoryPackOnDeserialized]
+    void OnDeserialized()
+    {
+        usePool = true;
+    }
+
+    static void Return<T>(Memory<T> memory) => Return((ReadOnlyMemory<T>)memory);
+
+    static void Return<T>(ReadOnlyMemory<T> memory)
+    {
+        if (MemoryMarshal.TryGetArray(memory, out var segment) && segment.Array is { Length: > 0 })
+        {
+            ArrayPool<T>.Shared.Return(segment.Array, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!usePool) return;
+
+        Return(Pool1); Pool1 = default;
+        Return(Pool2); Pool2 = default;
+        Return(Pool3); Pool3 = default;
+        Return(Pool4); Pool4 = default;
+    }
+}
+
+[MemoryPackable]
+public partial class StdData
+{
+    public int MyProperty { get; set; }
+}
+
+#endif


### PR DESCRIPTION
Provides `ArrayPoolMemoryFormatterAttribute<T>`, `ArrayPoolReadOnlyMemoryFormatterAttribtue<T>`.

User annotate `Memory<T>` by `[ArrayPoolMemoryFormatter<T>]`.
When deserialized, inner data is used from `ArrayPool<T>.Shared.Rent`.
Return must be do by yourself.
For example, you can tie the pattern to Dispose and return manually.


```csharp
[MemoryPackable]
public partial class MyClass : IDisposable
{
    [ArrayPoolMemoryFormatter<int>]
    public Memory<int> LargeArray { get; }

    public void Dispose()
    {
        // note: currently cannot determine if the data is from Pool or passed from outside, need to determine.
        if (MemoryMarshal.TryGetArray<int>(LargeArray, out var segment))
        {
            ArrayPool<int>.Shared.Return(segment.Array!);
        }
    }
}
```