### PR TITLE
feat: use C# nullable markers to export ts nullable types

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.TypeScript.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.TypeScript.cs
@@ -15,6 +15,7 @@ public record TypeScriptGenerateOptions
     public string OutputDirectory { get; set; } = default!;
     public string ImportExtension { get; set; } = default!;
     public bool ConvertPropertyName { get; set; } = true;
+    public bool EnableNullableTypes { get; set; } = false;
 }
 
 partial class MemoryPackGenerator

--- a/src/MemoryPack.Generator/MemoryPackGenerator.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.cs
@@ -146,10 +146,23 @@ public partial class MemoryPackGenerator : IIncrementalGenerator
                 {
                     convertProp = "true";
                 }
+
+                if (!configOptions.GlobalOptions.TryGetValue("build_property.MemoryPackGenerator_TypeScriptEnableNullableTypes", out var enableNullableTypes))
+                {
+                    enableNullableTypes = "false";
+                }
+
                 if (!bool.TryParse(convertProp, out var convert)) convert = true;
 
                 if (path == null) return null;
-                return new TypeScriptGenerateOptions { OutputDirectory = path, ImportExtension = ext, ConvertPropertyName = convert };
+
+                return new TypeScriptGenerateOptions
+                {
+                    OutputDirectory = path,
+                    ImportExtension = ext,
+                    ConvertPropertyName = convert,
+                    EnableNullableTypes = bool.TryParse(enableNullableTypes, out var enabledNullableTypesParsed) && enabledNullableTypesParsed
+                };
             });
 
         var typeScriptDeclarations = context.SyntaxProvider.ForAttributeWithMetadataName(


### PR DESCRIPTION
I've modified the code to allow the nullable type propagation from C# to TypeScript. 
Also, I added a flag to keep the old behavior and enable this feature.

@neuecc give me your opinions about that and point me out if I'm forgetting something or if I've missed anything to read the configuration that I've created. 

I still don't know too much about the project structure and I'm learning about code generators too. Also, I'm not being able to compile it on my Mac because there is no support for Native AOT compilation apparently.

Closes #88 