### PR TITLE
support underscore naming convention (private/internal) fields

### DIFF
--- a/src/MemoryPack.Generator/DiagnosticDescriptors.cs
+++ b/src/MemoryPack.Generator/DiagnosticDescriptors.cs
@@ -52,7 +52,7 @@ internal static class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor ConstructorHasNoMatchedParameter = new(
         id: "MEMPACK006",
         title: "MemoryPackObject's constructor has no matched parameter",
-        messageFormat: "The MemoryPackable object '{0}' constructor's all parameters must match serialized member name(case-insensitive)",
+        messageFormat: "The MemoryPackable object '{0}' constructor's parameter '{1}' must match a serialized member name(case-insensitive)",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/MemoryPack.Generator/Extensions.cs
+++ b/src/MemoryPack.Generator/Extensions.cs
@@ -5,6 +5,8 @@ namespace MemoryPack.Generator;
 
 internal static class Extensions
 {
+    private const string UnderScorePrefix = "_";
+
     public static string NewLine(this IEnumerable<string> source)
     {
         return string.Join(Environment.NewLine, source);
@@ -185,4 +187,23 @@ internal static class Extensions
             while (enumerator.MoveNext());
         }
     }
+
+    public static bool TryGetConstructorParameter(this IMethodSymbol constructor, ISymbol member, out string? constructorParameterName)
+    {
+        var constructorParameter = GetConstructorParameter(constructor, member.Name);
+        if (constructorParameter == null && member.Name.StartsWith(UnderScorePrefix))
+        {
+            constructorParameter = GetConstructorParameter(constructor, member.Name.Substring(UnderScorePrefix.Length));
+        }
+
+        constructorParameterName = constructorParameter?.Name;
+        return constructorParameter != null;
+
+        static IParameterSymbol? GetConstructorParameter(IMethodSymbol constructor, string name) => constructor.Parameters.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static bool ContainsConstructorParameter(this IEnumerable<MemberMeta> members, IParameterSymbol constructorParameter) =>
+        members.Any(x =>
+            x.IsConstructorParameter &&
+            string.Equals(constructorParameter.Name, x.ConstructorParameterName, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -896,7 +896,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
         }
         else
         {
-            var nameDict = Members.Where(x => x.Symbol != null).ToDictionary(x => x.Name, x => x.Name, StringComparer.OrdinalIgnoreCase);
+            var nameDict = Members.Where(x => x.Symbol != null && x.IsConstructorParameter).ToDictionary(x => x.ConstructorParameterName, x => x.Name, StringComparer.OrdinalIgnoreCase);
             var parameters = this.Constructor.Parameters
                 .Select(x =>
                 {

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
@@ -356,14 +356,15 @@ public partial class TypeMeta
             // check ctor members
             if (this.Constructor != null)
             {
-                var nameDict = new HashSet<string>(Members.Where(x => x.IsConstructorParameter).Select(x => x.Name), StringComparer.OrdinalIgnoreCase);
-                var allParameterExists = this.Constructor.Parameters.All(x => nameDict.Contains(x.Name));
-                if (!allParameterExists)
+                foreach (var parameter in Constructor.Parameters)
                 {
-                    var location = Constructor.Locations.FirstOrDefault() ?? syntax.Identifier.GetLocation();
+                    if (!Members.ContainsConstructorParameter(parameter))
+                    {
+                        var location = Constructor.Locations.FirstOrDefault() ?? syntax.Identifier.GetLocation();
 
-                    context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.ConstructorHasNoMatchedParameter, location, Symbol.Name));
-                    noError = false;
+                        context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.ConstructorHasNoMatchedParameter, location, Symbol.Name, parameter.Name));
+                        noError = false;
+                    }
                 }
             }
         }
@@ -567,6 +568,7 @@ partial class MemberMeta
     public bool IsSettable { get; }
     public bool IsAssignable { get; }
     public bool IsConstructorParameter { get; }
+    public string ConstructorParameterName { get; }
     public int Order { get; }
     public bool HasExplicitOrder { get; }
     public MemberKind Kind { get; }
@@ -599,7 +601,8 @@ partial class MemberMeta
 
         if (constructor != null)
         {
-            this.IsConstructorParameter = constructor.Parameters.Any(x => x.Name.Equals(Name, StringComparison.OrdinalIgnoreCase));
+            this.IsConstructorParameter = constructor.TryGetConstructorParameter(symbol, out var constructorParameterName);
+            this.ConstructorParameterName = constructorParameterName;
         }
         else
         {

--- a/tests/MemoryPack.Tests/ConstructorTest.cs
+++ b/tests/MemoryPack.Tests/ConstructorTest.cs
@@ -44,3 +44,17 @@ public partial class Beta
         this.Value1 = value1;
     }
 }
+
+// support underscore private/internal convention
+
+[MemoryPackable]
+public partial class Gamma
+{
+    [MemoryPackInclude]
+    private readonly string _test;
+
+    public Gamma(string test)
+    {
+        _test = test;
+    }
+}


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions#camel-case

Also list individual constructor parameters that cause MEMPACK006 so they are easier to track down.