### PR TITLE
Potential Fix for Issue #167

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -941,9 +941,12 @@ partial {{classOrStructOrRecord}} {{TypeName}}
 
 partial {{classOrInterfaceOrRecord}} {{TypeName}} : IMemoryPackFormatterRegister
 {
+    static partial void StaticConstructor();
+
     static {{Symbol.Name}}()
     {
         {{register}}
+        StaticConstructor();
     }
 
     [global::MemoryPack.Internal.Preserve]


### PR DESCRIPTION
Quick and easy way of allowing end users to still have static constructors in their `[MemoryPackable]` structures