### PR TITLE
Fix warnings for  source generator

### DIFF
--- a/sandbox/Benchmark/Benchmarks/ListFormatterVsDirect.cs
+++ b/sandbox/Benchmark/Benchmarks/ListFormatterVsDirect.cs
@@ -47,7 +47,7 @@ public class ListFormatterVsDirect
     public void SerializePackable()
     {
         var writer = new MemoryPackWriter<ArrayBufferWriter<byte>>(ref buffer, state);
-        MemoryPack.Formatters.ListFormatter.SerializePackable(ref writer, ref value!);
+        MemoryPack.Formatters.ListFormatter.SerializePackable(ref writer, value!);
         writer.Flush();
         buffer.Clear();
     }

--- a/src/MemoryPack.Core/Formatters/CollectionFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/CollectionFormatters.cs
@@ -53,7 +53,7 @@ namespace MemoryPack.Formatters
     {
         [Preserve]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializePackable<T, TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref List<T?>? value)
+        public static void SerializePackable<T, TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, List<T?>? value)
             where T : IMemoryPackable<T>
 #if NET7_0_OR_GREATER
             where TBufferWriter : IBufferWriter<byte>

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -485,7 +485,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
         }
 {{circularReferenceBody}}
 {{readBeginBody}}
-{{circularReferenceBody2}}        
+{{circularReferenceBody2}}
 {{Members.Where(x => x.Symbol != null).Select(x => $"        {x.MemberType.FullyQualifiedToString()} __{x.Name};").NewLine()}}
 
         {{(!isVersionTolerant ? "" : "var readCount = " + count + ";")}}
@@ -532,7 +532,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
             {
                 goto NEW;
             }
-{{(IsValueType ? "#if false" : "            else")}}            
+{{(IsValueType ? "#if false" : "            else")}}
             {
                 goto SET;
             }
@@ -669,7 +669,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
 {{EmitSerializeMembers(Members, "            ", toTempWriter: true, writeObjectHeader: false)}}
 
             tempWriter.Flush();
-            
+
             writer.WriteObjectHeader({{Members.Length}});
             for (int i = 0; i < {{Members.Length}}; i++)
             {
@@ -898,7 +898,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
         }
         else
         {
-            var nameDict = Members.Where(x => x.Symbol != null && x.IsConstructorParameter).ToDictionary(x => x.ConstructorParameterName, x => x.Name, StringComparer.OrdinalIgnoreCase);
+            var nameDict = Members.Where(x => x.IsConstructorParameter).ToDictionary(x => x.ConstructorParameterName, x => x.Name, StringComparer.OrdinalIgnoreCase);
             var parameters = this.Constructor.Parameters
                 .Select(x =>
                 {
@@ -982,7 +982,7 @@ partial {{classOrInterfaceOrRecord}} {{TypeName}} : IMemoryPackFormatterRegister
         {
 {{OnDeserializing.Select(x => "            " + x.Emit()).NewLine()}}
 {{EmitUnionDeserializeBody()}}
-{{OnDeserialized.Select(x => "            " + x.Emit()).NewLine()}}            
+{{OnDeserialized.Select(x => "            " + x.Emit()).NewLine()}}
         }
     }
 }
@@ -1039,7 +1039,7 @@ partial class {{TypeName}} : MemoryPackFormatter<{{symbolFullQualified}}>
         {
 {{OnDeserializing.Select(x => "            " + x.Emit()).NewLine()}}
 {{EmitUnionDeserializeBody()}}
-{{OnDeserialized.Select(x => "            " + x.Emit()).NewLine()}}            
+{{OnDeserialized.Select(x => "            " + x.Emit()).NewLine()}}
         }
 }
 
@@ -1051,7 +1051,7 @@ public static class {{initializerName}}
     public static void RegisterFormatter()
     {
 {{registerFormatterCode}}
-    }    
+    }
 }
 """;
 
@@ -1112,7 +1112,7 @@ public static class {{initializerName}}
 
                 switch (tag)
                 {
-{{writeBody}}                
+{{writeBody}}
                     default:
                         break;
                 }
@@ -1162,7 +1162,7 @@ public static class {{initializerName}}
 {{OnDeserialized.Select(x => "                " + x.Emit()).NewLine()}}
                 return;
             }
-        
+
             switch (tag)
             {
 {{readBody}}

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -1261,7 +1261,7 @@ public partial class MemberMeta
             case MemberKind.MemoryPackableArray:
                 return $"{writer}.WritePackableArray(value.@{Name});";
             case MemberKind.MemoryPackableList:
-                return $"global::MemoryPack.Formatters.ListFormatter.SerializePackable(ref {writer}, ref System.Runtime.CompilerServices.Unsafe.AsRef(value.@{Name}));";
+                return $"global::MemoryPack.Formatters.ListFormatter.SerializePackable(ref {writer}, value.@{Name});";
             case MemberKind.Array:
                 return $"{writer}.WriteArray(value.@{Name});";
             case MemberKind.Blank:

--- a/src/MemoryPack.Unity/Assets/Plugins/MemoryPack/Runtime/MemoryPack.Core/Formatters/CollectionFormatters.cs
+++ b/src/MemoryPack.Unity/Assets/Plugins/MemoryPack/Runtime/MemoryPack.Core/Formatters/CollectionFormatters.cs
@@ -62,7 +62,7 @@ namespace MemoryPack.Formatters
     {
         [Preserve]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializePackable<T>(ref MemoryPackWriter writer, ref List<T?>? value)
+        public static void SerializePackable<T>(ref MemoryPackWriter writer, List<T?>? value)
             where T : IMemoryPackable<T>
 #if NET7_0_OR_GREATER
             

--- a/src/MemoryPack.Unity/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs
+++ b/src/MemoryPack.Unity/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs
@@ -412,7 +412,8 @@ public static partial class UnitTestBuilder
         }
 
         // MemoryPack changed:
-        EditorUserBuildSettings.il2CppCodeGeneration = Il2CppCodeGeneration.OptimizeSpeed; //runtime
+        var namedBuildTarget = NamedBuildTarget.FromBuildTargetGroup(targetGroup);
+        PlayerSettings.SetIl2CppCodeGeneration(namedBuildTarget, Il2CppCodeGeneration.OptimizeSpeed);
 
         var buildOptions = new BuildPlayerOptions
         {
@@ -471,7 +472,7 @@ public static partial class UnitTestBuilder
             case BuildTarget.StandaloneWindows64:
             case BuildTarget.WSAPlayer:
                 return ".exe";
-            case BuildTarget.StandaloneOSX:                
+            case BuildTarget.StandaloneOSX:
                 return ".app";
             case BuildTarget.Android:
                 return ".apk";

--- a/src/MemoryPack.Unity/Assets/Scripts/MemoryPackObjects/MemberKinds.cs
+++ b/src/MemoryPack.Unity/Assets/Scripts/MemoryPackObjects/MemberKinds.cs
@@ -43,6 +43,12 @@ namespace MemoryPack.Tests.Models
             get { return ref kArray[0]; }
         }
 
+        public MemberKindsAllUnmanaged(int c, int d)
+        {
+            this.C = c;
+            this.D = d;
+        }
+
         public void SetH(int h)
         {
             this.H = h;


### PR DESCRIPTION
#177, #202

NOTE:
- One of the warnings is due to a change in thef` Unsafe.AsRef` modifier . Removing the unnecessary `Unsafe.AsRef` seemed the simplest solution, so I did so..