### PR TITLE
Fix AOT compatible of `Deserialize<T>`

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>

--- a/sandbox/ClassLibrary/ClassLibrary.csproj
+++ b/sandbox/ClassLibrary/ClassLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>11.0</LangVersion>
         <Nullable>enable</Nullable>

--- a/sandbox/NativeAot/NativeAot.csproj
+++ b/sandbox/NativeAot/NativeAot.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/sandbox/SandboxConsoleApp/Program.cs
+++ b/sandbox/SandboxConsoleApp/Program.cs
@@ -28,6 +28,21 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml.Linq;
 
+using MemoryPack;
+using System.Runtime.InteropServices;
+
+Console.WriteLine($"{RuntimeInformation.FrameworkDescription}");
+
+//var r = new MemPackTestObj() { Strings = new[] { "a", "b", "c" } };
+//var bytes = MemoryPackSerializer.Serialize(r);
+
+var bytes = Convert.FromBase64String("AwMAAAD+////AQAAAGH+////AQAAAGL+////AQAAAGMAAAAAAAAAAP////8=");
+Console.WriteLine(Convert.ToBase64String(bytes));
+var r2 = MemoryPackSerializer.Deserialize<MemPackTestObj>(bytes);
+foreach (var s in r2!.Strings)
+{
+    Console.WriteLine(s);
+}
 
 var value = new ListBytesSample();
 
@@ -46,6 +61,15 @@ MemoryPackSerializer.Deserialize<ListBytesSample>(bin, ref value);
 
 
 var span = CollectionsMarshal.AsSpan(value.Payload);
+
+
+[MemoryPackable]
+public partial record MemPackTestObj
+{
+    public string[] Strings { get; set; }
+    public DateTime Date { get; set; }
+    public string Name { get; set; }
+}
 
 
 [MemoryPackable]
@@ -206,7 +230,7 @@ public partial struct BrotliValue<T>
 
 
 
-//BrotliDecoder.TryDecompress(written, 
+//BrotliDecoder.TryDecompress(written,
 
 
 

--- a/sandbox/SandboxConsoleApp/SandboxConsoleApp.csproj
+++ b/sandbox/SandboxConsoleApp/SandboxConsoleApp.csproj
@@ -2,10 +2,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <PublishAot>true</PublishAot>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/MemoryPack.Core/MemoryPack.Core.csproj
+++ b/src/MemoryPack.Core/MemoryPack.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/MemoryPack.Core/MemoryPackSerializer.Deserialize.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializer.Deserialize.cs
@@ -11,14 +11,22 @@ public static partial class MemoryPackSerializer
     [ThreadStatic]
     static MemoryPackReaderOptionalState? threadStaticReaderOptionalState;
 
-    public static T? Deserialize<T>(ReadOnlySpan<byte> buffer, MemoryPackSerializerOptions? options = default)
+    public static T? Deserialize<
+#if NET5_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+        T>(ReadOnlySpan<byte> buffer, MemoryPackSerializerOptions? options = default)
     {
         T? value = default;
         Deserialize(buffer, ref value, options);
         return value;
     }
 
-    public static int Deserialize<T>(ReadOnlySpan<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
+    public static int Deserialize<
+#if NET5_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+        T>(ReadOnlySpan<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
     {
         if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
@@ -50,14 +58,22 @@ public static partial class MemoryPackSerializer
         }
     }
 
-    public static T? Deserialize<T>(in ReadOnlySequence<byte> buffer, MemoryPackSerializerOptions? options = default)
+    public static T? Deserialize<
+#if NET5_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+        T>(in ReadOnlySequence<byte> buffer, MemoryPackSerializerOptions? options = default)
     {
         T? value = default;
         Deserialize<T>(buffer, ref value, options);
         return value;
     }
 
-    public static int Deserialize<T>(in ReadOnlySequence<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
+    public static int Deserialize<
+#if NET5_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+        T>(in ReadOnlySequence<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
     {
         var state = threadStaticReaderOptionalState;
         if (state == null)
@@ -79,7 +95,11 @@ public static partial class MemoryPackSerializer
         }
     }
 
-    public static async ValueTask<T?> DeserializeAsync<T>(Stream stream, MemoryPackSerializerOptions? options = default, CancellationToken cancellationToken = default)
+    public static async ValueTask<T?> DeserializeAsync<
+#if NET5_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+        T>(Stream stream, MemoryPackSerializerOptions? options = default, CancellationToken cancellationToken = default)
     {
         if (stream is MemoryStream ms && ms.TryGetBuffer(out ArraySegment<byte> streamBuffer))
         {

--- a/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
+++ b/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
+++ b/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/MemoryPack.Tests/MemoryPack.Tests.csproj
+++ b/tests/MemoryPack.Tests/MemoryPack.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
#189 

If there is only Deserialize<T>() in the source code, the AOT build seems to fail at runtime.
This could be avoided by adding DynamicallyAccessedMembers to the type parameter T of Deserialize<T>.

NOTE: 
The AOT build seems to work as far as I have tried.
However, if configure the project to `<IsAotCompatible>true</IsAotCompatible>` results in a lot of warnings. (IL2026 , IL3050) 

The parts of the project that use reflection seem to work, but it seems difficult to avoid warnings.

It seems possible to add `[RequiresUnreferencedCode]` or `[RequiresDynamicCode]` in addition to this PR.  But in the end, applications that uses MemoryPack should see warnings.

