### PR TITLE
Expose media-type variable of `application/x-memorypack`

### DIFF
--- a/src/MemoryPack.AspNetCoreMvcFormatter/MediaTypeHeaderValues.cs
+++ b/src/MemoryPack.AspNetCoreMvcFormatter/MediaTypeHeaderValues.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Net.Http.Headers;
+
+namespace MemoryPack.AspNetCoreMvcFormatter;
+
+public static class MediaTypeHeaderValues
+{
+    public static readonly MediaTypeHeaderValue ApplicationMemoryPack =
+        MediaTypeHeaderValue.Parse("application/x-memorypack");
+}

--- a/src/MemoryPack.AspNetCoreMvcFormatter/MemoryPackInputFormatter.cs
+++ b/src/MemoryPack.AspNetCoreMvcFormatter/MemoryPackInputFormatter.cs
@@ -4,11 +4,9 @@ namespace MemoryPack.AspNetCoreMvcFormatter;
 
 public class MemoryPackInputFormatter : InputFormatter
 {
-    const string ContentType = "application/x-memorypack";
-
     public MemoryPackInputFormatter()
     {
-        SupportedMediaTypes.Add(ContentType);
+        SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationMemoryPack);
     }
 
     public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)

--- a/src/MemoryPack.AspNetCoreMvcFormatter/MemoryPackOutputFormatter.cs
+++ b/src/MemoryPack.AspNetCoreMvcFormatter/MemoryPackOutputFormatter.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc.Formatters;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace MemoryPack.AspNetCoreMvcFormatter;
 
 public class MemoryPackOutputFormatter : OutputFormatter
 {
-    const string ContentType = "application/x-memorypack";
     readonly MemoryPackSerializerOptions? options;
     readonly bool checkContentType = false;
 
@@ -17,14 +17,14 @@ public class MemoryPackOutputFormatter : OutputFormatter
     public MemoryPackOutputFormatter(MemoryPackSerializerOptions options)
     {
         this.options = options;
-        SupportedMediaTypes.Add(ContentType);
+        SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationMemoryPack);
     }
 
     public override bool CanWriteResult(OutputFormatterCanWriteContext context)
     {
         if (checkContentType)
         {
-            return (context.ContentType == ContentType);
+            return MediaTypeHeaderValues.ApplicationMemoryPack.MatchesMediaType(context.ContentType);
         }
         else
         {
@@ -34,7 +34,7 @@ public class MemoryPackOutputFormatter : OutputFormatter
 
     public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
     {
-        context.HttpContext.Response.ContentType = ContentType;
+        context.ContentType = MediaTypeHeaderValues.ApplicationMemoryPack.MediaType;
 
         if (context.Object == null)
         {


### PR DESCRIPTION
#229 

Since `application/x-memorypack` is a proprietary specification, it may be useful to reference constants.

Note: 
This changes has been tested in the SandboxWebApp project.