### PR TITLE
Allow snake_case for constructor parameters

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
@@ -358,7 +358,7 @@ public partial class TypeMeta
             {
                 foreach (var parameter in Constructor.Parameters)
                 {
-                    if (!Members.ContainsConstructorParameter(parameter))
+                    if (!Members.ContainsConstructorParameter(parameter.Name))
                     {
                         var location = Constructor.Locations.FirstOrDefault() ?? syntax.Identifier.GetLocation();
 
@@ -638,7 +638,7 @@ partial class MemberMeta
 
         if (constructor != null)
         {
-            this.IsConstructorParameter = constructor.TryGetConstructorParameter(symbol, out var constructorParameterName);
+            this.IsConstructorParameter = constructor.TryGetConstructorParameter(symbol.Name, out var constructorParameterName);
             this.ConstructorParameterName = constructorParameterName;
         }
         else

--- a/tests/MemoryPack.Tests/MemberNameMatchTest.cs
+++ b/tests/MemoryPack.Tests/MemberNameMatchTest.cs
@@ -1,0 +1,27 @@
+﻿namespace MemoryPack.Tests;
+
+public class MemberNameMatchTest
+{
+    [Fact]
+    public void MatchMemberNameTest()
+    {
+        byte[] serialized = MemoryPackSerializer.Serialize(new MemberNameMatchTestClass(1, 2, 3));
+        MemberNameMatchTestClass deserialized = MemoryPackSerializer.Deserialize<MemberNameMatchTestClass>(serialized)!;
+        Assert.Equal(1, deserialized.PascalCase);
+        Assert.Equal(2, deserialized.LowerCamelCase);
+        Assert.Equal(3, deserialized.SnakeCase);
+    }
+}
+
+[MemoryPackable]
+public partial class MemberNameMatchTestClass
+{
+    public int PascalCase;
+    public int LowerCamelCase;
+    public int SnakeCase;
+    public MemberNameMatchTestClass(int PascalCase, int lowerCamelCase, int snake_case) {
+        this.PascalCase = PascalCase;
+        LowerCamelCase = lowerCamelCase;
+        SnakeCase = snake_case;
+    }
+}


### PR DESCRIPTION
Fixes #240.

```cs
[MemoryPackable]
public partial class MemberNameMatchTestClass
{
    public int PascalCase;
    public int LowerCamelCase;
    public int SnakeCase;
    public MemberNameMatchTestClass(int PascalCase, int lowerCamelCase, int snake_case) {
        this.PascalCase = PascalCase;
        LowerCamelCase = lowerCamelCase;
        SnakeCase = snake_case; // Previously invalid
    }
}
```