### PR TITLE
Fix BrotliCompressor.CopyToAsync buffer is not enough

### DIFF
--- a/src/MemoryPack.Core/Compression/BrotliCompressor.cs
+++ b/src/MemoryPack.Core/Compression/BrotliCompressor.cs
@@ -151,17 +151,20 @@ public
 
         using var encoder = new BrotliEncoder(quality, window);
 
+        foreach (var item in bufferWriter)
+        {
+            if (item.Length > bufferSize)
+            {
+                bufferSize = item.Length;
+            }
+        }
+
         var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
         try
         {
             foreach (var item in bufferWriter)
             {
                 var source = item;
-                if (source.Length > buffer.Length)
-                {
-                    ArrayPool<byte>.Shared.Return(buffer);
-                    buffer = ArrayPool<byte>.Shared.Rent(source.Length);
-                }
                 var lastResult = OperationStatus.DestinationTooSmall;
                 while (lastResult == OperationStatus.DestinationTooSmall)
                 {


### PR DESCRIPTION
#243 

BrotoliEncoder.Compress seems to return `OperationState.DestinationTooSmall` even when the destination buffer is short.

If the length of one BufferSegment is very large (more than the bufferSize parameter), finalState was DestinationTooSmall, the method would complete.
( In #243, MemoryStream is used).