### PR TITLE
Fix problem when default value expression contains namespace

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.TypeScript.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.TypeScript.cs
@@ -38,7 +38,7 @@ partial class MemoryPackGenerator
             return null;
         }
 
-        var typeMeta = new TypeMeta(typeSymbol, reference);
+        var typeMeta = new TypeMeta(semanticModel, typeSymbol, reference);
 
         if (typeMeta.GenerateType is not (GenerateType.Object or GenerateType.Union))
         {

--- a/tests/MemoryPack.Tests/Models/DefaultValues.cs
+++ b/tests/MemoryPack.Tests/Models/DefaultValues.cs
@@ -1,4 +1,11 @@
+using System.Collections.Generic;
+
 namespace MemoryPack.Tests.Models;
+
+enum TestEnum
+{
+    A, B, C
+}
 
 [MemoryPackable]
 partial class DefaultValuePlaceholder
@@ -24,6 +31,9 @@ partial class PropertyDefaultValue
     public float Z { get; set; } = 678.9f;
     public string S { get; set; } = "aaaaaaaaa";
     public bool B { get; set; } = true;
+    public List<string> Alpha { get; set; } = new List<string>(new HashSet<string>());
+    public TestEnum TestEnum { get; set; } = TestEnum.A;
+    public (TestEnum, List<string>) Tuple { get; set; } = (TestEnum.A, new List<string>(new HashSet<string>()));
 }
 
 [MemoryPackable]


### PR DESCRIPTION
Fix #250, #252

In #242, to output the default value expression. 
However, it seems that name resolution may not work as it is.

For example,
```cs
public List<MyType> MyProperty = new List<MyType>();.
```
The default value of such an expression should have been as follows.

```cs
new global::System.Collections.Generic.List<MyNameSpace.MyType>();.
```