### PR TITLE
Add attr to not overwrite Member with default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ public partial class Person3
 When serializing/deserializing, MemoryPack can invoke a before/after event using the `[MemoryPackOnSerializing]`, `[MemoryPackOnSerialized]`, `[MemoryPackOnDeserializing]`, `[MemoryPackOnDeserialized]` attributes. It can annotate both static and instance (non-static) methods, and public and private methods. 
 
 ```csharp
-[MemoryPackable]
+    [MemoryPackable]
 public partial class MethodCallSample
 {
     // method call order is static -> instance
@@ -545,6 +545,28 @@ public partial class VersionCheck
 ```
 
 In use-case, store old data (to file, to redis, etc...) and read to new schema is always ok. In the RPC scenario, schema exists both on the client and the server side, the client must be updated before the server. An updated client has no problem connecting to the old server but an old client can not connect to a new server.
+
+
+By default, when the old data read to new schema, any members not on the data side are initialized with the `default` literal.
+If you want to avoid this and use initial values of field/properties, you can use `[SuppressDefaultInitialization]`.
+
+```cs
+[MemoryPackable]
+public partial class DefaultValue
+{
+    public string Prop1 { get; set; }
+
+    [SuppressDefaultInitialization]
+    public int Prop2 { get; set; } = 111; // < if old data is missing, set `111`.
+    
+    public int Prop3 { get; set; } = 222; // < if old data is missing, set `default`.
+}
+```
+
+ `[SuppressDefaultInitialization]` has following disadvantages:
+- Cannot be used with readonly, init-only, and required modifier.
+=- May not be the best performance due to increased conditional branching. (But it would be negligible.)
+
 
 The next [Serialization info](#serialization-info) section shows how to check for schema changes, e.g., by CI, to prevent accidents.
 

--- a/src/MemoryPack.Core/Attributes.cs
+++ b/src/MemoryPack.Core/Attributes.cs
@@ -153,3 +153,6 @@ public sealed class MemoryPackOnDeserializedAttribute : Attribute
 public sealed class GenerateTypeScriptAttribute : Attribute
 {
 }
+
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public sealed class SkipOverwriteByDefaultAttribute : Attribute;

--- a/src/MemoryPack.Core/Attributes.cs
+++ b/src/MemoryPack.Core/Attributes.cs
@@ -155,4 +155,4 @@ public sealed class GenerateTypeScriptAttribute : Attribute
 }
 
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-public sealed class SkipOverwriteByDefaultAttribute : Attribute;
+public sealed class SuppressDefaultInitialization : Attribute;

--- a/src/MemoryPack.Generator/DiagnosticDescriptors.cs
+++ b/src/MemoryPack.Generator/DiagnosticDescriptors.cs
@@ -324,4 +324,12 @@ internal static class DiagnosticDescriptors
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor SuppressDefaultInitializationMustBeSettable = new(
+        id: "MEMPACK040",
+        title: "Readonly member cannot specify [SuppressDefaultInitialization]",
+        messageFormat: "The MemoryPackable object '{0}' member '{1}' has [SuppressDefaultInitialization], it cannot be readonly, init-only and required.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -539,7 +539,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
 
     SET:
         {{(!IsUseEmptyConstructor ? "goto NEW;" : "")}}
-{{Members.Where(x => x.Symbol != null).Where(x => x.IsAssignable).Select(x => $"        {(IsUseEmptyConstructor ? "" : "// ")}value.@{x.Name} = __{x.Name};").NewLine()}}
+{{Members.Where(x => x.IsAssignable).Select(x => $"        {(IsUseEmptyConstructor ? "" : "// ")}value.@{x.Name} = __{x.Name};").NewLine()}}
         goto READ_END;
 
     NEW:
@@ -547,6 +547,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
         {
 {{EmitDeserializeConstruction("            ")}}
         };
+{{Members.Select((x, i) => (x, i)).Where(v => v.x.SkipOverwriteByDefault && v.x.IsAssignable).Select(v => $"        if ({v.i + 1} <= count) value.@{v.x.Name} = __{v.x.Name};").NewLine()}}
     READ_END:
 {{readEndBody}}
 """;
@@ -916,7 +917,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
     {
         // all value is deserialized, __Name is exsits.
         return string.Join("," + Environment.NewLine, Members
-            .Where(x => x.IsSettable && !x.IsConstructorParameter)
+            .Where(x => x is { IsSettable: true, IsConstructorParameter: false, SkipOverwriteByDefault: false })
             .Select(x => $"{indent}@{x.Name} = __{x.Name}"));
     }
 

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -927,16 +927,11 @@ partial {{classOrStructOrRecord}} {{TypeName}}
             .Select((x, i) => (x, i))
             .Where(v => v.x.SuppressDefaultInitialization);
 
-        if (GenerateType is GenerateType.VersionTolerant or GenerateType.CircularReference)
-        {
-            return members
-                .Select(v => $"{indent}if (deltas[{v.i}] != 0) value.@{v.x.Name} = __{v.x.Name};")
-                .NewLine();
-        }
+        var lines = GenerateType is GenerateType.VersionTolerant or GenerateType.CircularReference
+            ? members.Select(v => $"{indent}if (deltas.Length > {v.i} && deltas[{v.i}] != 0) value.@{v.x.Name} = __{v.x.Name};")
+            : members.Select(v => $"{indent}if ({v.i + 1} <= count) value.@{v.x.Name} = __{v.x.Name};");
 
-        return members
-            .Select(v => $"{indent}if ({v.i + 1} <= count) value.@{v.x.Name} = __{v.x.Name};")
-            .NewLine();
+        return lines.NewLine();
     }
 
     string EmitUnionTemplate(IGeneratorContext context)

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
@@ -615,6 +615,7 @@ partial class MemberMeta
     public int Order { get; }
     public bool HasExplicitOrder { get; }
     public MemberKind Kind { get; }
+    public bool SkipOverwriteByDefault { get; }
 
     MemberMeta(int order)
     {
@@ -630,6 +631,7 @@ partial class MemberMeta
         this.Symbol = symbol;
         this.Name = symbol.Name;
         this.Order = sequentialOrder;
+        this.SkipOverwriteByDefault = symbol.ContainsAttribute(references.SkipOverwriteDefaultAttribute);
         var orderAttr = symbol.GetAttribute(references.MemoryPackOrderAttribute);
         if (orderAttr != null)
         {

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
@@ -375,6 +375,11 @@ public partial class TypeMeta
                     context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.ReadOnlyFieldMustBeConstructorMember, item.GetLocation(syntax), Symbol.Name, item.Name));
                     noError = false;
                 }
+                else if (item is { SuppressDefaultInitialization: true, IsAssignable: false })
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.SuppressDefaultInitializationMustBeSettable, item.GetLocation(syntax), Symbol.Name, item.Name));
+                    noError = false;
+                }
             }
         }
 
@@ -615,7 +620,7 @@ partial class MemberMeta
     public int Order { get; }
     public bool HasExplicitOrder { get; }
     public MemberKind Kind { get; }
-    public bool SkipOverwriteByDefault { get; }
+    public bool SuppressDefaultInitialization { get; }
 
     MemberMeta(int order)
     {
@@ -631,7 +636,7 @@ partial class MemberMeta
         this.Symbol = symbol;
         this.Name = symbol.Name;
         this.Order = sequentialOrder;
-        this.SkipOverwriteByDefault = symbol.ContainsAttribute(references.SkipOverwriteDefaultAttribute);
+        this.SuppressDefaultInitialization = symbol.ContainsAttribute(references.SkipOverwriteDefaultAttribute);
         var orderAttr = symbol.GetAttribute(references.MemoryPackOrderAttribute);
         if (orderAttr != null)
         {

--- a/src/MemoryPack.Generator/ReferenceSymbols.cs
+++ b/src/MemoryPack.Generator/ReferenceSymbols.cs
@@ -47,7 +47,7 @@ public class ReferenceSymbols
         MemoryPackOnSerializedAttribute = GetTypeByMetadataName("MemoryPack.MemoryPackOnSerializedAttribute");
         MemoryPackOnDeserializingAttribute = GetTypeByMetadataName("MemoryPack.MemoryPackOnDeserializingAttribute");
         MemoryPackOnDeserializedAttribute = GetTypeByMetadataName("MemoryPack.MemoryPackOnDeserializedAttribute");
-        SkipOverwriteDefaultAttribute = GetTypeByMetadataName("MemoryPack.SkipOverwriteByDefaultAttribute");
+        SkipOverwriteDefaultAttribute = GetTypeByMetadataName("MemoryPack.SuppressDefaultInitialization");
         GenerateTypeScriptAttribute = GetTypeByMetadataName(MemoryPackGenerator.GenerateTypeScriptAttributeFullName);
         IMemoryPackable = GetTypeByMetadataName("MemoryPack.IMemoryPackable`1").ConstructUnboundGenericType();
         KnownTypes = new WellKnownTypes(this);

--- a/src/MemoryPack.Generator/ReferenceSymbols.cs
+++ b/src/MemoryPack.Generator/ReferenceSymbols.cs
@@ -22,6 +22,7 @@ public class ReferenceSymbols
     public INamedTypeSymbol MemoryPackOnSerializedAttribute { get; }
     public INamedTypeSymbol MemoryPackOnDeserializingAttribute { get; }
     public INamedTypeSymbol MemoryPackOnDeserializedAttribute { get; }
+    public INamedTypeSymbol SkipOverwriteDefaultAttribute { get; }
     public INamedTypeSymbol GenerateTypeScriptAttribute { get; }
     public INamedTypeSymbol IMemoryPackable { get; }
 
@@ -46,6 +47,7 @@ public class ReferenceSymbols
         MemoryPackOnSerializedAttribute = GetTypeByMetadataName("MemoryPack.MemoryPackOnSerializedAttribute");
         MemoryPackOnDeserializingAttribute = GetTypeByMetadataName("MemoryPack.MemoryPackOnDeserializingAttribute");
         MemoryPackOnDeserializedAttribute = GetTypeByMetadataName("MemoryPack.MemoryPackOnDeserializedAttribute");
+        SkipOverwriteDefaultAttribute = GetTypeByMetadataName("MemoryPack.SkipOverwriteByDefaultAttribute");
         GenerateTypeScriptAttribute = GetTypeByMetadataName(MemoryPackGenerator.GenerateTypeScriptAttributeFullName);
         IMemoryPackable = GetTypeByMetadataName("MemoryPack.IMemoryPackable`1").ConstructUnboundGenericType();
         KnownTypes = new WellKnownTypes(this);
@@ -161,7 +163,7 @@ public class ReferenceSymbols
 
             { "System.Collections.Generic.KeyValuePair<,>", "global::MemoryPack.Formatters.KeyValuePairFormatter<TREPLACE>" },
             { "System.Lazy<>", "global::MemoryPack.Formatters.LazyFormatter<TREPLACE>" },
-            
+
             // TupleFormatters
             { "System.Tuple<>", "global::MemoryPack.Formatters.TupleFormatter<TREPLACE>" },
             { "System.Tuple<,>", "global::MemoryPack.Formatters.TupleFormatter<TREPLACE>" },

--- a/tests/MemoryPack.Tests/DefaultValueTest.cs
+++ b/tests/MemoryPack.Tests/DefaultValueTest.cs
@@ -5,24 +5,26 @@ namespace MemoryPack.Tests;
 public class DefaultValueTest
 {
     [Fact]
-    public void FieldDefaultValue()
+    public void SuppressDefaultInitialization()
     {
         var bin = MemoryPackSerializer.Serialize(new DefaultValuePlaceholder { X = 1 });
-        var expected = new FieldDefaultValue();
-        var deserializedValue = MemoryPackSerializer.Deserialize<FieldDefaultValue>(bin)!;
+        var expected = new HasDefaultValue();
+        var deserializedValue = MemoryPackSerializer.Deserialize<HasDefaultValue>(bin)!;
         deserializedValue.Y.Should().Be(default);
-        deserializedValue.Z.Should().Be(expected.Z);
-        deserializedValue.FromMethod.Should().Be(expected.FromMethod);
+        deserializedValue.Z.Should().Be(default);
+        deserializedValue.Y2.Should().Be(expected.Y2);
+        deserializedValue.Z2.Should().Be(expected.Z2);
     }
 
     [Fact]
-    public void PropertyDefaultValue()
+    public void SuppressDefaultInitialization_VersionTolerant()
     {
         var bin = MemoryPackSerializer.Serialize(new DefaultValuePlaceholder { X = 1 });
-        var expected = new PropertyDefaultValue();
-        var deserializedValue = MemoryPackSerializer.Deserialize<PropertyDefaultValue>(bin)!;
+        var expected = new HasDefaultValueWithVersionTolerant();
+        var deserializedValue = MemoryPackSerializer.Deserialize<HasDefaultValueWithVersionTolerant>(bin)!;
         deserializedValue.Y.Should().Be(default);
         deserializedValue.Z.Should().Be(expected.Z);
-        deserializedValue.FromMethod.Should().Be(expected.FromMethod);
+        deserializedValue.Y2.Should().Be(expected.Y2);
+        deserializedValue.Z2.Should().Be(expected.Z2);
     }
 }

--- a/tests/MemoryPack.Tests/DefaultValueTest.cs
+++ b/tests/MemoryPack.Tests/DefaultValueTest.cs
@@ -1,0 +1,28 @@
+﻿using MemoryPack.Tests.Models;
+
+namespace MemoryPack.Tests;
+
+public class DefaultValueTest
+{
+    [Fact]
+    public void FieldDefaultValue()
+    {
+        var bin = MemoryPackSerializer.Serialize(new DefaultValuePlaceholder { X = 1 });
+        var expected = new FieldDefaultValue();
+        var deserializedValue = MemoryPackSerializer.Deserialize<FieldDefaultValue>(bin)!;
+        deserializedValue.Y.Should().Be(default);
+        deserializedValue.Z.Should().Be(expected.Z);
+        deserializedValue.FromMethod.Should().Be(expected.FromMethod);
+    }
+
+    [Fact]
+    public void PropertyDefaultValue()
+    {
+        var bin = MemoryPackSerializer.Serialize(new DefaultValuePlaceholder { X = 1 });
+        var expected = new PropertyDefaultValue();
+        var deserializedValue = MemoryPackSerializer.Deserialize<PropertyDefaultValue>(bin)!;
+        deserializedValue.Y.Should().Be(default);
+        deserializedValue.Z.Should().Be(expected.Z);
+        deserializedValue.FromMethod.Should().Be(expected.FromMethod);
+    }
+}

--- a/tests/MemoryPack.Tests/DefaultValueTest.cs
+++ b/tests/MemoryPack.Tests/DefaultValueTest.cs
@@ -19,11 +19,11 @@ public class DefaultValueTest
     [Fact]
     public void SuppressDefaultInitialization_VersionTolerant()
     {
-        var bin = MemoryPackSerializer.Serialize(new DefaultValuePlaceholder { X = 1 });
+        var bin = MemoryPackSerializer.Serialize(new DefaultValuePlaceholderWithVersionTolerant { X = 1 });
         var expected = new HasDefaultValueWithVersionTolerant();
         var deserializedValue = MemoryPackSerializer.Deserialize<HasDefaultValueWithVersionTolerant>(bin)!;
         deserializedValue.Y.Should().Be(default);
-        deserializedValue.Z.Should().Be(expected.Z);
+        deserializedValue.Z.Should().Be(default);
         deserializedValue.Y2.Should().Be(expected.Y2);
         deserializedValue.Z2.Should().Be(expected.Z2);
     }

--- a/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
+++ b/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
@@ -642,6 +642,22 @@ public partial class Tester
 
 """);
     }
+
+    [Fact]
+    public void MEMPACK040_SuppressDefaultInitializationMustBeSettable()
+    {
+        Compile(40, """
+using MemoryPack;
+
+[MemoryPackable]
+public partial class Tester
+{
+    [SuppressDefaultInitialization]
+    public required int I1 { get; init; }
+}
+
+""");
+    }
 }
 
 

--- a/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
+++ b/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
@@ -653,10 +653,41 @@ using MemoryPack;
 public partial class Tester
 {
     [SuppressDefaultInitialization]
-    public required int I1 { get; init; }
+    public required int I1 { get; set; }
 }
 
 """);
+
+        Compile(40, """
+using MemoryPack;
+
+[MemoryPackable]
+public partial class Tester
+{
+    [SuppressDefaultInitialization]
+    public int I1 { get; init; }
+}
+
+""");
+
+        Compile(40, """
+using MemoryPack;
+
+[MemoryPackable]
+public partial class Tester
+{
+    [SuppressDefaultInitialization]
+    public readonly int I1;
+
+    [MemoryPackConstructor]
+    public Tester(int i1)
+    {
+        I1 = i1;
+    }
+}
+
+""");
+
     }
 }
 

--- a/tests/MemoryPack.Tests/Models/DefaultValues.cs
+++ b/tests/MemoryPack.Tests/Models/DefaultValues.cs
@@ -1,12 +1,4 @@
-using System;
-using System.Collections.Generic;
-
 namespace MemoryPack.Tests.Models;
-
-enum TestEnum
-{
-    A, B, C
-}
 
 [MemoryPackable]
 partial class DefaultValuePlaceholder
@@ -14,56 +6,42 @@ partial class DefaultValuePlaceholder
     public int X { get; set; }
 }
 
+static class StaticMethod
+{
+    public static int GetNumberCalls;
+
+    public static int GetNumber()
+    {
+        GetNumberCalls++;
+        return 100;
+    }
+}
+
 [MemoryPackable]
 partial class FieldDefaultValue
 {
     public int X;
     public int Y = 12345;
+
+    [SkipOverwriteByDefault]
     public float Z = 678.9f;
-    public string S = "aaaaaaaaa";
-    public bool B = true;
+
+    [SkipOverwriteByDefault]
+    public int FromMethod = StaticMethod.GetNumber();
 }
 
 [MemoryPackable]
 partial class PropertyDefaultValue
 {
-    internal enum NestedEnum
-    {
-        A, B
-    }
-
-    public int X { get; set; }
+    public int X { get; init; }
     public int Y { get; set; } = 12345;
+
+    [SkipOverwriteByDefault]
     public float Z { get; set; } = 678.9f;
-    public string S { get; set; } = "aaaaaaaaa";
-    public bool B { get; set; } = true;
-    public List<string> Alpha { get; set; } = new List<string>(new HashSet<string>());
-    public TestEnum E { get; set; } = TestEnum.A;
-    public NestedEnum E2 { get; set; } = NestedEnum.A;
-    public (TestEnum, List<string>) Tuple { get; set; } = (TestEnum.A, new List<string>(new HashSet<string>()));
-    public DateTime Struct { get; set; } = default!;
-}
 
-[MemoryPackable]
-partial class CtorParamDefaultValue
-{
-    public int X;
-    public int Y;
-    public float Z;
-    public string S;
-    public bool B;
-    public decimal D;
-    public DateTime StructValue;
+    [SkipOverwriteByDefault]
+    public float W { get; init; } = 678.9f;
 
-    [MemoryPackConstructor]
-    public CtorParamDefaultValue(int x, int y = 12345, float z = 678.9f, string s = "aaaaaa", bool b = true, decimal d = 99M, DateTime structValue = default)
-    {
-        X = x;
-        Y = y;
-        Z = z;
-        S = s;
-        B = b;
-        D = d;
-        StructValue = structValue;
-    }
+    [SkipOverwriteByDefault]
+    public int FromMethod { get; set; } = StaticMethod.GetNumber();
 }

--- a/tests/MemoryPack.Tests/Models/DefaultValues.cs
+++ b/tests/MemoryPack.Tests/Models/DefaultValues.cs
@@ -23,10 +23,10 @@ partial class FieldDefaultValue
     public int X;
     public int Y = 12345;
 
-    [SkipOverwriteByDefault]
+    [SuppressDefaultInitialization]
     public float Z = 678.9f;
 
-    [SkipOverwriteByDefault]
+    [SuppressDefaultInitialization]
     public int FromMethod = StaticMethod.GetNumber();
 }
 
@@ -36,12 +36,12 @@ partial class PropertyDefaultValue
     public int X { get; init; }
     public int Y { get; set; } = 12345;
 
-    [SkipOverwriteByDefault]
+    [SuppressDefaultInitialization]
     public float Z { get; set; } = 678.9f;
 
-    [SkipOverwriteByDefault]
+    [SuppressDefaultInitialization]
     public float W { get; init; } = 678.9f;
 
-    [SkipOverwriteByDefault]
+    [SuppressDefaultInitialization]
     public int FromMethod { get; set; } = StaticMethod.GetNumber();
 }

--- a/tests/MemoryPack.Tests/Models/DefaultValues.cs
+++ b/tests/MemoryPack.Tests/Models/DefaultValues.cs
@@ -7,6 +7,12 @@ partial class DefaultValuePlaceholder
 }
 
 [MemoryPackable(GenerateType.VersionTolerant, SerializeLayout.Sequential)]
+partial class DefaultValuePlaceholderWithVersionTolerant
+{
+    public int X { get; set; }
+}
+
+[MemoryPackable(GenerateType.VersionTolerant, SerializeLayout.Sequential)]
 partial class HasDefaultValueWithVersionTolerant
 {
     public int X;

--- a/tests/MemoryPack.Tests/Models/DefaultValues.cs
+++ b/tests/MemoryPack.Tests/Models/DefaultValues.cs
@@ -6,42 +6,32 @@ partial class DefaultValuePlaceholder
     public int X { get; set; }
 }
 
-static class StaticMethod
-{
-    public static int GetNumberCalls;
-
-    public static int GetNumber()
-    {
-        GetNumberCalls++;
-        return 100;
-    }
-}
-
-[MemoryPackable]
-partial class FieldDefaultValue
+[MemoryPackable(GenerateType.VersionTolerant, SerializeLayout.Sequential)]
+partial class HasDefaultValueWithVersionTolerant
 {
     public int X;
+
     public int Y = 12345;
-
-    [SuppressDefaultInitialization]
-    public float Z = 678.9f;
-
-    [SuppressDefaultInitialization]
-    public int FromMethod = StaticMethod.GetNumber();
-}
-
-[MemoryPackable]
-partial class PropertyDefaultValue
-{
-    public int X { get; init; }
-    public int Y { get; set; } = 12345;
-
-    [SuppressDefaultInitialization]
     public float Z { get; set; } = 678.9f;
 
     [SuppressDefaultInitialization]
-    public float W { get; init; } = 678.9f;
+    public int Y2 = 12345;
 
     [SuppressDefaultInitialization]
-    public int FromMethod { get; set; } = StaticMethod.GetNumber();
+    public float Z2 { get; set; } = 678.9f;
+}
+
+[MemoryPackable]
+partial class HasDefaultValue
+{
+    public int X;
+
+    public int Y = 12345;
+    public float Z { get; set; } = 678.9f;
+
+    [SuppressDefaultInitialization]
+    public int Y2 = 12345;
+
+    [SuppressDefaultInitialization]
+    public float Z2 { get; set; } = 678.9f;
 }


### PR DESCRIPTION
#185 

Add `[SuppressDefaultInitialization]` attribute.

e.g)

```cs
[MemoryPackable]
partial class A
{
    public int X;
    public int Y = 12345;

    [SkipOverwriteByDefault]
    public float Z = 678.9f;
}
```

```cs
    NEW:
        value = new FieldDefaultValue()
        {
            @X = __X, 
            @Y = __Y
        };
        if (3 <= count) value.@Z = __Z; // < Added this branch
```