### PR TITLE
feat: MemoryPackSerializer.ResetState, ResetReaderState, ResetWriterState

### DIFF
--- a/src/MemoryPack.Core/MemoryPackSerializer.StateBackup.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializer.StateBackup.cs
@@ -1,0 +1,86 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace MemoryPack;
+
+public static partial class MemoryPackSerializer
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static StateBackup BackupState() => new(true);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static SerializerStateBackup BackupSerializerState() => new(true);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static DeserializerStateBackup BackupDeserializerState() => new(true);
+
+    // Nested types
+
+    public readonly struct StateBackup : IDisposable
+    {
+        readonly SerializerWriterThreadStaticState? _threadStaticState;
+        readonly MemoryPackWriterOptionalState? _threadStaticWriterOptionalState;
+        readonly MemoryPackReaderOptionalState? _threadStaticReaderOptionalState;
+        readonly bool _isValid;
+
+        internal StateBackup(bool isValid)
+        {
+            _threadStaticState = threadStaticState;
+            _threadStaticWriterOptionalState = threadStaticWriterOptionalState;
+            _threadStaticReaderOptionalState = threadStaticReaderOptionalState;
+            _isValid = isValid;
+        }
+
+        public void Dispose()
+        {
+            if (!_isValid)
+                return;
+
+            threadStaticState = _threadStaticState;
+            threadStaticWriterOptionalState = _threadStaticWriterOptionalState;
+            threadStaticReaderOptionalState = _threadStaticReaderOptionalState;
+        }
+    }
+
+    public readonly struct SerializerStateBackup : IDisposable
+    {
+        readonly SerializerWriterThreadStaticState? _threadStaticState;
+        readonly MemoryPackWriterOptionalState? _threadStaticWriterOptionalState;
+        readonly bool _isValid;
+
+        internal SerializerStateBackup(bool isValid)
+        {
+            _threadStaticState = threadStaticState;
+            _threadStaticWriterOptionalState = threadStaticWriterOptionalState;
+            _isValid = isValid;
+        }
+
+        public void Dispose()
+        {
+            if (!_isValid)
+                return;
+
+            threadStaticState = _threadStaticState;
+            threadStaticWriterOptionalState = _threadStaticWriterOptionalState;
+        }
+    }
+
+    public readonly struct DeserializerStateBackup : IDisposable
+    {
+        readonly MemoryPackReaderOptionalState? _threadStaticReaderOptionalState;
+        readonly bool _isValid;
+
+        internal DeserializerStateBackup(bool isValid)
+        {
+            _threadStaticReaderOptionalState = threadStaticReaderOptionalState;
+            _isValid = isValid;
+        }
+
+        public void Dispose()
+        {
+            if (!_isValid)
+                return;
+
+            threadStaticReaderOptionalState = _threadStaticReaderOptionalState;
+        }
+    }
+}


### PR DESCRIPTION
Sometimes you want to invoke `MemoryPackSerializer.Serialize` while serializing another type (e.g. to serialize a complex nested structure into a byte array on serialization). And sometimes you want to do the same on deserialization. Since MemoryPack uses `[ThreadStatic]` to store its serializer/deserializer state, this doesn't work - unless you backup its state & reset it.

The provided implementation does exactly this. Currently we have to resort to CreateDelegate/ILEmit-based workaround to address that, this change would address the problem in more straightforward way.