### PR TITLE
Adds `pragma warning disable CS0618` to generated *.MemoryPackFormatter.g.cs file

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -76,6 +76,7 @@ partial class MemoryPackGenerator
 #pragma warning disable CS0162 // Unreachable code
 #pragma warning disable CS0164 // This label has not been referenced
 #pragma warning disable CS0219 // Variable assigned but never used
+#pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 #pragma warning disable CS8601 // Possible null reference assignment
 #pragma warning disable CS8602


### PR DESCRIPTION
Close #276 