### PR TITLE
Fix issue 304: Use of C# 9 feature in library targeted at C# 7.

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -1089,7 +1089,7 @@ public static class {{initializerName}}
         var elements = UnionTags.Select(x => $"            {{ typeof({ToUnionTagTypeFullyQualifiedToString(x.Type)}), {x.Tag} }},").NewLine();
 
         return $$"""
-        static readonly System.Collections.Generic.Dictionary<Type, ushort> __typeToTag = new({{UnionTags.Length}})
+        static readonly System.Collections.Generic.Dictionary<Type, ushort> __typeToTag = new System.Collections.Generic.Dictionary<Type, ushort>({{UnionTags.Length}})
         {
 {{elements}}
         };

--- a/src/MemoryPack/MemoryPack.csproj
+++ b/src/MemoryPack/MemoryPack.csproj
@@ -8,6 +8,7 @@
         <NoWarn>$(NoWarn);NU5128</NoWarn>
         <PackageTags>serializer</PackageTags>
         <Description>Zero encoding extreme performance binary serializer for C#.</Description>
+        <Version>1.21.2</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Calling new (someSize) instead of new Dictionary<type,ushort>(someSize) is not allowed in .net versions below 9, but this library is supposed to be .net 7 compatible.

See https://github.com/Cysharp/MemoryPack/issues/304 for more info.