### PR TITLE
[issue-300] Fix for Unmanaged Structs Using GenerateType.VersionTolerant (MEMPACK041)

### DIFF
--- a/src/MemoryPack.Generator/DiagnosticDescriptors.cs
+++ b/src/MemoryPack.Generator/DiagnosticDescriptors.cs
@@ -332,4 +332,12 @@ internal static class DiagnosticDescriptors
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor VersionTolerantOnUnmanagedStruct = new(
+        id: "MEMPACK041",
+        title: "Invalid usage of VersionTolerant on unmanaged struct",
+        messageFormat: "The unmanaged struct '{0}' cannot be used for VersionTolerant serialization.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
@@ -294,6 +294,12 @@ public partial class TypeMeta
 
         if (this.IsUnmanagedType)
         {
+            if (GenerateType is GenerateType.VersionTolerant)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.VersionTolerantOnUnmanagedStruct, syntax.Identifier.GetLocation(), Symbol.Name));
+                noError = false;
+            }
+
             var structLayoutFields = this.Symbol.GetAllMembers()
                 .OfType<IFieldSymbol>()
                 .Select(x =>

--- a/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
+++ b/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
@@ -687,9 +687,22 @@ public partial class Tester
 }
 
 """);
+    }
 
+    [Fact]
+    public void MEMPACK041_UnmanagedStructCannotBeVersionTolerant()
+    {
+        Compile(41, """
+using MemoryPack;
+
+[MemoryPackable(GenerateType.VersionTolerant)]
+public partial struct Tester
+{
+    [MemoryPackOrder(0)]
+    public int I1 { get; init; }
+}
+""");
     }
 }
-
 
 #endif


### PR DESCRIPTION
I’ve resolved the [issue](https://github.com/Cysharp/MemoryPack/issues/300) where unmanaged structs were incorrectly allowed to use GenerateType.VersionTolerant with the following updates:

1. **Diagnostic MEMPACK041:** Triggers an error when an unmanaged struct is marked with VersionTolerant, as unmanaged structs should remain unchanged and cannot support version-tolerant serialization.
2. **Generator Fix:** The generator now correctly raises an error for unmanaged structs to ensure backward compatibility.
3. **Unit Test:** Added `MEMPACK041_UnmanagedStructCannotBeVersionTolerant` to validate the behavior.

Please review and provide feedback. Looking forward to improving MemoryPack’s reliability with this fix.