### PR TITLE
Added support for nested classes

### DIFF
--- a/src/MemoryPack.Generator/DiagnosticDescriptors.cs
+++ b/src/MemoryPack.Generator/DiagnosticDescriptors.cs
@@ -17,14 +17,6 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public static readonly DiagnosticDescriptor NestedNotAllow = new(
-        id: "MEMPACK002",
-        title: "MemoryPackable object must not be nested type",
-        messageFormat: "The MemoryPackable object '{0}' must be not nested type",
-        category: Category,
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
-
     public static readonly DiagnosticDescriptor AbstractMustUnion = new(
         id: "MEMPACK003",
         title: "abstract/interface type of MemoryPackable object must annotate with Union",
@@ -337,6 +329,14 @@ internal static class DiagnosticDescriptors
         id: "MEMPACK041",
         title: "Invalid usage of VersionTolerant on unmanaged struct",
         messageFormat: "The unmanaged struct '{0}' cannot be used for VersionTolerant serialization.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor NestedContainingTypesMustBePartial = new(
+        id: "MEMPACK042",
+        title: "Nested MemoryPackable object's containing type(s) must be partial",
+        messageFormat: "The MemoryPackable object '{0}' containing type(s) must be partial",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
+++ b/tests/MemoryPack.Tests/GeneratorDiagnosticsTest.cs
@@ -44,22 +44,6 @@ public class Hoge
     }
 
     [Fact]
-    public void MEMPACK002_NestedNotAllow()
-    {
-        Compile(2, """
-using MemoryPack;
-
-public partial class Hoge
-{
-    [MemoryPackable]
-    public partial class Huga
-    {
-    }
-}
-""");
-    }
-
-    [Fact]
     public void MEMPACK003_AbstractMustUnion()
     {
         Compile(3, """
@@ -702,6 +686,23 @@ public partial struct Tester
     public int I1 { get; init; }
 }
 """);
+    }
+
+    [Fact]
+    public void MEMPACK042_NestedContainingTypesMustBePartial()
+    {
+        Compile(42, """
+                    using MemoryPack;
+
+                    public struct NestedContainer
+                    {
+                        [MemoryPackable]
+                        public partial struct NestedStruct
+                        {
+                            public int I1 { get; init; }
+                        }
+                    }
+                    """);
     }
 }
 

--- a/tests/MemoryPack.Tests/GeneratorTest.cs
+++ b/tests/MemoryPack.Tests/GeneratorTest.cs
@@ -51,6 +51,13 @@ public class GeneratorTest
     }
 
     [Fact]
+    public void Nested()
+    {
+        VerifyEquivalent(new NestedContainer.StandardTypeNested() { One = 9999 });
+        VerifyEquivalent(new DoublyNestedContainer.DoublyNestedContainerInner.StandardTypeDoublyNested() { One = 9999 });
+    }
+
+    [Fact]
     public void Null()
     {
         var bin = MemoryPackSerializer.Serialize<StandardTypeOne>(null);

--- a/tests/MemoryPack.Tests/Models/StandardType.cs
+++ b/tests/MemoryPack.Tests/Models/StandardType.cs
@@ -62,6 +62,27 @@ namespace MemoryPack.Tests.Models
         }
     }
 
+    public partial class NestedContainer
+    {
+        [MemoryPackable]
+        public partial class StandardTypeNested
+        {
+            public int One { get; set; }
+        }
+    }
+
+    public partial class DoublyNestedContainer
+    {
+        public partial class DoublyNestedContainerInner
+        {
+            [MemoryPackable]
+            public partial class StandardTypeDoublyNested
+            {
+                public int One { get; set; }
+            }
+        }
+    }
+
 
     [MemoryPackable]
     public partial class WithArray


### PR DESCRIPTION
Nested class declarations now supported. Any amount of nesting should now work. Removed diagnostic MEMPACK002 as it no longer applies. added diagnostic MEMPACK042 to report that one of the containing types is not partial. Added unit tests for nested generation functionality and for new diagnostic.