### PR TITLE
Fix generator crash in classes with parameterized constructor

### DIFF
--- a/src/MemoryPack.Generator/Extensions.cs
+++ b/src/MemoryPack.Generator/Extensions.cs
@@ -291,4 +291,22 @@ internal static class Extensions
         members.Any(x =>
             x.IsConstructorParameter &&
             string.Equals(constructorParameter.Name, x.ConstructorParameterName, StringComparison.OrdinalIgnoreCase));
+
+    public static bool TryGetConstructorMember(this IEnumerable<MemberMeta> members, IParameterSymbol constructorParameter, out MemberMeta? member)
+    {
+        member = members.FirstOrDefault(m =>
+        {
+            if (EqualsConstructorParameter(constructorParameter, m.Name)) return true;
+            if (m.Name.StartsWith(UnderScorePrefix))
+            {
+                return EqualsConstructorParameter(constructorParameter, m.Name.Substring(UnderScorePrefix.Length));
+            }
+
+            return false;
+        });
+
+        return member != null;
+
+        static bool EqualsConstructorParameter(IParameterSymbol constructorParameter, string name) => constructorParameter.Name.Equals(name, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
This PR fixes a generator crash in classes with parameterized constructor when there are duplicate properties and fields with the same name as the parameter.
The related issue is #373.