### PR TITLE
Interface and Abstract Class Nesting

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -312,7 +312,6 @@ public partial class TypeMeta
 
         var containingTypeDeclarations = new List<string>();
         var containingType = Symbol.ContainingType;
-
         while (containingType is not null)
         {
             var isInterface = containingType.TypeKind == TypeKind.Interface;

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -105,6 +105,30 @@ using MemoryPack;
         }
         sb.AppendLine();
 
+        // emit type info
+        if (unionFormatter)
+        {
+            AppendTypeRemarks(serializationInfoLogDirectoryPath, typeMeta, sb, fullType);
+            typeMeta.EmitUnionFormatterTemplate(sb, context, typeSymbol);
+        }
+        else
+        {
+            // Emit the type.  Wrap the append method to capture the current variables.
+            typeMeta.Emit(sb, context,
+                () => AppendTypeRemarks(serializationInfoLogDirectoryPath, typeMeta, sb, fullType));
+        }
+
+        if (!ns.IsGlobalNamespace && !context.IsCSharp10OrGreater())
+        {
+            sb.AppendLine($"}}");
+        }
+
+        var code = sb.ToString();
+        context.AddSource($"{fullType}.MemoryPackFormatter.g.cs", code);
+    }
+
+    static void AppendTypeRemarks(string? serializationInfoLogDirectoryPath, TypeMeta typeMeta, StringBuilder sb, string fullType)
+    {
         // Write document comment as remarks
         if (typeMeta.GenerateType is GenerateType.Object or GenerateType.VersionTolerant or GenerateType.CircularReference)
         {
@@ -131,24 +155,6 @@ using MemoryPack;
                 }
             }
         }
-
-        // emit type info
-        if (unionFormatter)
-        {
-            typeMeta.EmitUnionFormatterTemplate(sb, context, typeSymbol);
-        }
-        else
-        {
-            typeMeta.Emit(sb, context);
-        }
-
-        if (!ns.IsGlobalNamespace && !context.IsCSharp10OrGreater())
-        {
-            sb.AppendLine($"}}");
-        }
-
-        var code = sb.ToString();
-        context.AddSource($"{fullType}.MemoryPackFormatter.g.cs", code);
     }
 
     static bool IsPartial(TypeDeclarationSyntax typeDeclaration)
@@ -253,17 +259,54 @@ using MemoryPack;
 
 public partial class TypeMeta
 {
-    public void Emit(StringBuilder writer, IGeneratorContext context)
+    public void Emit(StringBuilder writer, IGeneratorContext context, Action appendTypeRemarks)
     {
+        var containingTypeDeclarations = new List<string>();
+        var containingType = Symbol.ContainingType;
+        while (containingType is not null)
+        {
+            var isInterface = containingType.TypeKind == TypeKind.Interface;
+            containingTypeDeclarations.Add((containingType.IsRecord, containingType.IsValueType, containingType.IsAbstract, isInterface) switch
+            {
+                (true, true, false, false) => $"partial record struct {containingType.Name}",
+                (true, false, false, false) => $"partial record {containingType.Name}",
+                (false, true, false, false) => $"partial struct {containingType.Name}",
+                (false, false, false, false) => $"partial class {containingType.Name}",
+                (false, false, true, false) => $"abstract partial class {containingType.Name}",
+                (false, false, true, true) => $"partial interface {containingType.Name}",
+                _ => $"partial class {containingType.Name}"
+            });
+            containingType = containingType.ContainingType;
+        }
+        containingTypeDeclarations.Reverse();
+
+        foreach (var declaration in containingTypeDeclarations)
+        {
+            writer.AppendLine(declaration);
+            writer.AppendLine("{");
+        }
+
+
+        // Write the documentation header after any containing classes.
+        appendTypeRemarks.Invoke();
+
         if (IsUnion)
         {
             writer.AppendLine(EmitUnionTemplate(context));
-            return;
         }
 
         if (GenerateType == GenerateType.Collection)
         {
             writer.AppendLine(EmitGenericCollectionTemplate(context));
+        }
+
+        // Write the closing braces.
+        if (IsUnion || GenerateType == GenerateType.Collection)
+        {
+            for(int i = 0; i < containingTypeDeclarations.Count; ++i)
+            {
+                writer.AppendLine("}");
+            }
             return;
         }
 
@@ -309,24 +352,6 @@ public partial class TypeMeta
             (false, true) => "struct",
             (false, false) => "class",
         };
-
-        var containingTypeDeclarations = new List<string>();
-        var containingType = Symbol.ContainingType;
-        while (containingType is not null)
-        {
-            var isInterface = containingType.TypeKind == TypeKind.Interface;
-            containingTypeDeclarations.Add((containingType.IsRecord, containingType.IsValueType, containingType.IsAbstract, isInterface) switch
-            {
-                (true, true, false, false) => $"partial record struct {containingType.Name}",
-                (true, false, false, false) => $"partial record {containingType.Name}",
-                (false, true, false, false) => $"partial struct {containingType.Name}",
-                (false, false, false, false) => $"partial class {containingType.Name}",
-                (false, false, true, false) => $"abstract partial class {containingType.Name}",
-                (false, false, true, true) => $"partial interface {containingType.Name}",
-            });
-            containingType = containingType.ContainingType;
-        }
-        containingTypeDeclarations.Reverse();
 
         var nullable = IsValueType ? "" : "?";
 
@@ -376,12 +401,6 @@ public partial class TypeMeta
         var serializeMethodSignarture = context.IsForUnity
             ? "Serialize(ref MemoryPackWriter"
             : "Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter>";
-
-        foreach (var declaration in containingTypeDeclarations)
-        {
-            writer.AppendLine(declaration);
-            writer.AppendLine("{");
-        }
 
         writer.AppendLine($$"""
 partial {{classOrStructOrRecord}} {{TypeName}} : IMemoryPackable<{{TypeName}}>{{fixedSizeInterface}}

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -312,14 +312,18 @@ public partial class TypeMeta
 
         var containingTypeDeclarations = new List<string>();
         var containingType = Symbol.ContainingType;
+
         while (containingType is not null)
         {
-            containingTypeDeclarations.Add((containingType.IsRecord, containingType.IsValueType) switch
+            var isInterface = containingType.TypeKind == TypeKind.Interface;
+            containingTypeDeclarations.Add((containingType.IsRecord, containingType.IsValueType, containingType.IsAbstract, isInterface) switch
             {
-                (true, true) => $"partial record struct {containingType.Name}",
-                (true, false) => $"partial record {containingType.Name}",
-                (false, true) => $"partial struct {containingType.Name}",
-                (false, false) => $"partial class {containingType.Name}",
+                (true, true, false, false) => $"partial record struct {containingType.Name}",
+                (true, false, false, false) => $"partial record {containingType.Name}",
+                (false, true, false, false) => $"partial struct {containingType.Name}",
+                (false, false, false, false) => $"partial class {containingType.Name}",
+                (false, false, true, false) => $"abstract partial class {containingType.Name}",
+                (false, false, true, true) => $"partial interface {containingType.Name}",
             });
             containingType = containingType.ContainingType;
         }

--- a/tests/MemoryPack.Tests/GeneratorTest.cs
+++ b/tests/MemoryPack.Tests/GeneratorTest.cs
@@ -54,6 +54,10 @@ public class GeneratorTest
     public void Nested()
     {
         VerifyEquivalent(new NestedContainer.StandardTypeNested() { One = 9999 });
+        VerifyEquivalent(new NestedStructContainer.StandardTypeNested() { One = 9999 });
+        VerifyEquivalent(new NestedRecordStructContainer.StandardTypeNested() { One = 9999 });
+        VerifyEquivalent(new NestedInterfaceContainer.StandardTypeNested() { One = 9999 });
+        VerifyEquivalent(new NestedAbstractClassContainer.StandardTypeNested() { One = 9999 });
         VerifyEquivalent(new DoublyNestedContainer.DoublyNestedContainerInner.StandardTypeDoublyNested() { One = 9999 });
     }
 

--- a/tests/MemoryPack.Tests/Models/StandardType.cs
+++ b/tests/MemoryPack.Tests/Models/StandardType.cs
@@ -71,6 +71,42 @@ namespace MemoryPack.Tests.Models
         }
     }
 
+    public partial struct NestedStructContainer
+    {
+        [MemoryPackable]
+        public partial class StandardTypeNested
+        {
+            public int One { get; set; }
+        }
+    }
+
+    public partial record struct NestedRecordStructContainer
+    {
+        [MemoryPackable]
+        public partial class StandardTypeNested
+        {
+            public int One { get; set; }
+        }
+    }
+
+    public partial interface NestedInterfaceContainer
+    {
+        [MemoryPackable]
+        public partial class StandardTypeNested
+        {
+            public int One { get; set; }
+        }
+    }
+
+    public abstract partial class NestedAbstractClassContainer
+    {
+        [MemoryPackable]
+        public partial class StandardTypeNested
+        {
+            public int One { get; set; }
+        }
+    }
+
     public partial class DoublyNestedContainer
     {
         public partial class DoublyNestedContainerInner
@@ -82,7 +118,6 @@ namespace MemoryPack.Tests.Models
             }
         }
     }
-
 
     [MemoryPackable]
     public partial class WithArray

--- a/tests/MemoryPack.Tests/Models/StandardType.cs
+++ b/tests/MemoryPack.Tests/Models/StandardType.cs
@@ -119,6 +119,7 @@ namespace MemoryPack.Tests.Models
         }
     }
 
+
     [MemoryPackable]
     public partial class WithArray
     {


### PR DESCRIPTION
Expands upon #333 and allows for nesting inside `abstract partial class` and `partial interface`.
Added tests for each type of nesting allowed.

This additionally fixes an issue with the current implementation where the XML remarks are added to the containing type instead of the MemoryPack type itself.

The only part about this that I feel unhappy with is the added Action in the `Emit(StringBuilder writer, IGeneratorContext context, Action appendTypeRemarks)` method.  The reason I did this was I needed to capture multiple variables in another scope with the `AppendTypeRemarks(string? serializationInfoLogDirectoryPath, TypeMeta typeMeta, StringBuilder sb, string fullType)` method as the remarks need to be applied to different locations based upon usage of either the `typeMeta.EmitUnionFormatterTemplate` or the `typeMeta.Emit`

If you have a better idea, I am happy to re-work it to be cleaner.