### PR TITLE
Update target frameworks & packages

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
@@ -21,24 +21,24 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
         <PackageReference Include="BinaryPack" Version="1.0.3" />
-        <PackageReference Include="K4os.Compression.LZ4" Version="1.2.16" />
-        <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.2.16" />
-        <PackageReference Include="MessagePack" Version="2.4.35" />
-        <PackageReference Include="MessagePackAnalyzer" Version="2.4.35">
+        <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
+        <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
+        <PackageReference Include="MessagePack" Version="3.1.3" />
+        <PackageReference Include="MessagePackAnalyzer" Version="3.1.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="7.0.0">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+        <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="9.1.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Orleans.Serialization" Version="7.0.0" />
-        <PackageReference Include="protobuf-net" Version="3.1.25" />
-        <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Orleans.Serialization" Version="9.1.2" />
+        <PackageReference Include="protobuf-net" Version="3.2.46" />
+        <PackageReference Include="System.IO.Pipelines" Version="9.0.3" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sandbox/Benchmark/BenchmarkNetUtilities/PayloadColumn.cs
+++ b/sandbox/Benchmark/BenchmarkNetUtilities/PayloadColumn.cs
@@ -2,6 +2,7 @@
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using Perfolizer.Metrology;
 
 namespace Benchmark.BenchmarkNetUtilities;
 
@@ -39,7 +40,7 @@ public class PayloadColumn : IColumn
         {
             var instance = Activator.CreateInstance(benchmarkCase.Descriptor.Type);
             var result = (byte[])methodInfo.Invoke(instance, null)!;
-            return new SizeValue(result.LongLength).ToString(null);
+            return new SizeValue(result.LongLength).ToString();
         }
         else
         {

--- a/sandbox/ClassLibrary/ClassLibrary.csproj
+++ b/sandbox/ClassLibrary/ClassLibrary.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>11.0</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\MemoryPack.Core\MemoryPack.Core.csproj" />
-        <ProjectReference Include="..\..\src\MemoryPack.Generator\MemoryPack.Generator.csproj">
+        <ProjectReference Include="../../src/MemoryPack.Core/MemoryPack.Core.csproj" />
+        <ProjectReference Include="../../src/MemoryPack.Generator/MemoryPack.Generator.csproj">
             <OutputItemType>Analyzer</OutputItemType>
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         </ProjectReference>

--- a/sandbox/Net6VsNet7/Net6VsNet7.csproj
+++ b/sandbox/Net6VsNet7/Net6VsNet7.csproj
@@ -2,15 +2,15 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sandbox/SandboxConsoleApp/SandboxConsoleApp.csproj
+++ b/sandbox/SandboxConsoleApp/SandboxConsoleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -16,10 +16,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ConsoleAppFramework" Version="4.2.3" />
-        <PackageReference Include="MessagePack" Version="2.4.35" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
+        <PackageReference Include="ConsoleAppFramework" Version="5.4.1" />
+        <PackageReference Include="MessagePack" Version="3.1.3" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.IO.Pipelines" Version="9.0.3" />
     </ItemGroup>
 
     <!-- output memoerypack serialization info to directory -->

--- a/sandbox/SandboxConsoleApp/SystemTextJsonChecker.cs
+++ b/sandbox/SandboxConsoleApp/SystemTextJsonChecker.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ConsoleAppFramework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,18 +12,18 @@ namespace SandboxConsoleApp;
 // check the System.Text.Json's constructor select rule.
 
 // For a class, if the only constructor is a parameterized one, that constructor will be used.
-// For a struct, or a class with multiple constructors, specify the one to use by applying the[JsonConstructor] attribute.
+// For a struct, or a class with multiple constructors, specify the one to use by applying the [JsonConstructor] attribute.
 // When the attribute is not used, a public parameterless constructor is always used if present.
 
 // MemoryPack choose class/struct as same rule.
-// If has no explicit constrtucotr, use parameterless one.
+// If has no explicit constructor, use parameterless one.
 // If has a one parameterless/parameterized constructor, choose it.
-// If has multiple construcotrs, should apply [MemoryPackConstructor] attribute(no automatically choose one), otherwise generator error it.
+// If has multiple constructor, should apply [MemoryPackConstructor] attribute (no automatically choose one), otherwise generator error it.
 
 // The parameter names of a parameterized constructor must match the property names.
 // Matching is case-insensitive, and the constructor parameter must match the actual property name.
 
-class SystemTextJsonChecker : ConsoleAppBase
+class SystemTextJsonChecker
 {
     //[RootCommand]
     public void JsonConstructorSelector()
@@ -57,7 +58,7 @@ class SystemTextJsonChecker : ConsoleAppBase
         JsonSerializer.Deserialize<Seven>(seven);
     }
 
-    [RootCommand]
+    [Command("")]
     public void PrivateSerialization()
     {
         // private field/property can not annnotate JsonInclude

--- a/sandbox/SandboxNet6/SandboxNet6.csproj
+++ b/sandbox/SandboxNet6/SandboxNet6.csproj
@@ -2,9 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/sandbox/SandboxWebApp/SandboxWebApp.csproj
+++ b/sandbox/SandboxWebApp/SandboxWebApp.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.9.0-beta">
+        <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.8.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/MemoryPack.AspNetCoreMvcFormatter/MemoryPack.AspNetCoreMvcFormatter.csproj
+++ b/src/MemoryPack.AspNetCoreMvcFormatter/MemoryPack.AspNetCoreMvcFormatter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-        <ProjectReference Include="..\MemoryPack.Core\MemoryPack.Core.csproj" />
+        <ProjectReference Include="../MemoryPack.Core/MemoryPack.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/MemoryPack.Core/MemoryPack.Core.csproj
+++ b/src/MemoryPack.Core/MemoryPack.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -17,8 +17,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-        <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.1" />
+        <PackageReference Include="System.Collections.Immutable" Version="9.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MemoryPack.Generator/MemoryPack.Generator.csproj
+++ b/src/MemoryPack.Generator/MemoryPack.Generator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>12</LangVersion>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <AnalyzerLanguage>cs</AnalyzerLanguage>
         <Nullable>enable</Nullable>
@@ -22,8 +22,8 @@
         <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
         <!-- require to support SyntaxValueProvider.ForAttributeWithMetadataName(Roslyn 4.3.0, VS2022 17.3) -->
         <!-- Unity 2022.3.12f1 or newer supports 4.3.0 -->
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/MemoryPack.Generator/MemoryPackGenerator.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.cs
@@ -297,11 +297,11 @@ public partial class MemoryPackGenerator : IIncrementalGenerator
     {
         SourceProductionContext context;
 
-        public GeneratorContext(SourceProductionContext context, LanguageVersion languageVersion, bool isNet70OrGreater)
+        public GeneratorContext(SourceProductionContext context, LanguageVersion languageVersion, bool isNet7OrGreater)
         {
             this.context = context;
             this.LanguageVersion = languageVersion;
-            this.IsNet7OrGreater = isNet70OrGreater;
+            this.IsNet7OrGreater = isNet7OrGreater;
         }
 
         public CancellationToken CancellationToken => context.CancellationToken;

--- a/src/MemoryPack.Streaming/MemoryPack.Streaming.csproj
+++ b/src/MemoryPack.Streaming/MemoryPack.Streaming.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);CS1591;CA2255</NoWarn>
@@ -15,11 +15,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
+        <PackageReference Include="System.IO.Pipelines" Version="9.0.3" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\MemoryPack.Core\MemoryPack.Core.csproj" />
+        <ProjectReference Include="../MemoryPack.Core/MemoryPack.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
+++ b/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -16,8 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\MemoryPack.Core\MemoryPack.Core.csproj" />
-        <ProjectReference Include="..\..\src\MemoryPack.Generator\MemoryPack.Generator.csproj">
+        <ProjectReference Include="../MemoryPack.Core/MemoryPack.Core.csproj" />
+        <ProjectReference Include="../../src/MemoryPack.Generator/MemoryPack.Generator.csproj">
             <OutputItemType>Analyzer</OutputItemType>
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         </ProjectReference>

--- a/src/MemoryPack/MemoryPack.csproj
+++ b/src/MemoryPack/MemoryPack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <!-- This project is meta package -->
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <IncludeContentInPack>true</IncludeContentInPack>
@@ -11,10 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="..\..\LICENSE.md" />
+        <EmbeddedResource Include="../../LICENSE.md" />
         <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-        <ProjectReference Include="..\MemoryPack.Core\MemoryPack.Core.csproj" />
-        <ProjectReference Include="..\MemoryPack.Generator\MemoryPack.Generator.csproj" />
+        <ProjectReference Include="../MemoryPack.Core/MemoryPack.Core.csproj" />
+        <ProjectReference Include="../MemoryPack.Generator/MemoryPack.Generator.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/MemoryPack.Tests/MemoryPack.Tests.csproj
+++ b/tests/MemoryPack.Tests/MemoryPack.Tests.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+        <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="RandomFixtureKit" Version="1.0.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/MemoryPack.Tests/SourceGeneratorTests/IncrementalGeneratorTest.cs
+++ b/tests/MemoryPack.Tests/SourceGeneratorTests/IncrementalGeneratorTest.cs
@@ -34,5 +34,3 @@ public partial class MyClass
 
     }
 }
-
-

--- a/tests/MemoryPack.Tests/Utils/CSharpGeneratorRunner.cs
+++ b/tests/MemoryPack.Tests/Utils/CSharpGeneratorRunner.cs
@@ -51,7 +51,7 @@ global using MemoryPack;
         {
             preprocessorSymbols = new[] { "NET7_0_OR_GREATER" };
         }
-        var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp11, preprocessorSymbols: preprocessorSymbols);
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest, preprocessorSymbols: preprocessorSymbols);
 
         var driver = CSharpGeneratorDriver.Create(new MemoryPackGenerator()).WithUpdatedParseOptions(parseOptions);
         if (options != null)
@@ -68,7 +68,7 @@ global using MemoryPack;
 
     public static (string Key, string Reasons)[][] GetIncrementalGeneratorTrackedStepsReasons(string keyPrefixFilter, params string[] sources)
     {
-        var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp11);
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
         var driver = CSharpGeneratorDriver.Create(
             [new MemoryPackGenerator().AsSourceGenerator()],
             driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true))


### PR DESCRIPTION
This pull request updates the target frameworks and packages of every project, including one vulnerable dependency and one beta dependency. MemoryPack drops `net7.0` and adds `net9.0` (as well as the existing `netstandard2.1` and `net8.0`).