### PR TITLE
Remove redundant checks in advance if possible

### DIFF
--- a/src/MemoryPack.Core/Formatters/MultiDimensionalArrayFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/MultiDimensionalArrayFormatters.cs
@@ -34,7 +34,7 @@ public sealed class TwoDimensionalArrayFormatter<T> : MemoryPackFormatter<T?[,]>
 
             Unsafe.WriteUnaligned(ref dest, value.Length);
             Unsafe.CopyBlockUnaligned(ref Unsafe.Add(ref dest, 4), ref src, (uint)byteCount);
-            writer.Advance(byteCount + 4);
+            writer.AdvanceUnsafe(byteCount + 4);
         }
         else
 #endif
@@ -146,7 +146,7 @@ public sealed class ThreeDimensionalArrayFormatter<T> : MemoryPackFormatter<T?[,
 
             Unsafe.WriteUnaligned(ref dest, value.Length);
             Unsafe.CopyBlockUnaligned(ref Unsafe.Add(ref dest, 4), ref src, (uint)byteCount);
-            writer.Advance(byteCount + 4);
+            writer.AdvanceUnsafe(byteCount + 4);
         }
         else
 #endif
@@ -199,7 +199,7 @@ public sealed class ThreeDimensionalArrayFormatter<T> : MemoryPackFormatter<T?[,
             ref var src = ref reader.GetSpanReference(byteCount);
             Unsafe.CopyBlockUnaligned(ref dest, ref src, (uint)byteCount);
 
-            reader.Advance(byteCount);
+            reader.AdvanceUnsafe(byteCount);
         }
         else
 #endif
@@ -265,7 +265,7 @@ public sealed class FourDimensionalArrayFormatter<T> : MemoryPackFormatter<T?[,,
 
             Unsafe.WriteUnaligned(ref dest, value.Length);
             Unsafe.CopyBlockUnaligned(ref Unsafe.Add(ref dest, 4), ref src, (uint)byteCount);
-            writer.Advance(byteCount + 4);
+            writer.AdvanceUnsafe(byteCount + 4);
         }
         else
 #endif

--- a/src/MemoryPack.Core/Formatters/StringBuilderFormatter.cs
+++ b/src/MemoryPack.Core/Formatters/StringBuilderFormatter.cs
@@ -30,7 +30,7 @@ public sealed class StringBuilderFormatter : MemoryPackFormatter<StringBuilder>
                 ref var src = ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(chunk.Span));
                 Unsafe.CopyBlockUnaligned(ref p, ref src, (uint)chunk.Length * 2);
 
-                writer.Advance(chunk.Length * 2);
+                writer.AdvanceUnsafe(chunk.Length * 2);
             }
             return;
         }
@@ -67,6 +67,6 @@ public sealed class StringBuilderFormatter : MemoryPackFormatter<StringBuilder>
         var src = MemoryMarshal.CreateSpan(ref Unsafe.As<byte, char>(ref p), length);
         value.Append(src);
 
-        reader.Advance(size);
+        reader.AdvanceUnsafe(size);
     }
 }

--- a/src/MemoryPack.Core/Formatters/UnmanagedFormatter.cs
+++ b/src/MemoryPack.Core/Formatters/UnmanagedFormatter.cs
@@ -17,14 +17,14 @@ where T : unmanaged
     public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref T value)
     {
         Unsafe.WriteUnaligned(ref writer.GetSpanReference(Unsafe.SizeOf<T>()), value);
-        writer.Advance(Unsafe.SizeOf<T>());
+        writer.AdvanceUnsafe(Unsafe.SizeOf<T>());
     }
 
     [Preserve]
     public override void Deserialize(ref MemoryPackReader reader, scoped ref T value)
     {
         value = Unsafe.ReadUnaligned<T>(ref reader.GetSpanReference(Unsafe.SizeOf<T>()));
-        reader.Advance(Unsafe.SizeOf<T>());
+        reader.AdvanceUnsafe(Unsafe.SizeOf<T>());
     }
 }
 
@@ -35,13 +35,13 @@ public sealed class DangerousUnmanagedFormatter<T> : MemoryPackFormatter<T>
     public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref T? value)
     {
         Unsafe.WriteUnaligned(ref writer.GetSpanReference(Unsafe.SizeOf<T>()), value);
-        writer.Advance(Unsafe.SizeOf<T>());
+        writer.AdvanceUnsafe(Unsafe.SizeOf<T>());
     }
 
     [Preserve]
     public override void Deserialize(ref MemoryPackReader reader, scoped ref T? value)
     {
         value = Unsafe.ReadUnaligned<T>(ref reader.GetSpanReference(Unsafe.SizeOf<T>()));
-        reader.Advance(Unsafe.SizeOf<T>());
+        reader.AdvanceUnsafe(Unsafe.SizeOf<T>());
     }
 }

--- a/src/MemoryPack.Core/MemoryPackReader.Unmanaged.cs
+++ b/src/MemoryPack.Core/MemoryPackReader.Unmanaged.cs
@@ -13,7 +13,7 @@ public ref partial struct MemoryPackReader
         var size = Unsafe.SizeOf<T1>();
         ref var spanRef = ref GetSpanReference(size);
         value1 = Unsafe.ReadUnaligned<T1>(ref spanRef);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -25,7 +25,7 @@ public ref partial struct MemoryPackReader
         ref var spanRef = ref GetSpanReference(size);
         value1 = Unsafe.ReadUnaligned<T1>(ref spanRef);
         value2 = Unsafe.ReadUnaligned<T2>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -39,7 +39,7 @@ public ref partial struct MemoryPackReader
         value1 = Unsafe.ReadUnaligned<T1>(ref spanRef);
         value2 = Unsafe.ReadUnaligned<T2>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()));
         value3 = Unsafe.ReadUnaligned<T3>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -55,7 +55,7 @@ public ref partial struct MemoryPackReader
         value2 = Unsafe.ReadUnaligned<T2>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()));
         value3 = Unsafe.ReadUnaligned<T3>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()));
         value4 = Unsafe.ReadUnaligned<T4>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -73,7 +73,7 @@ public ref partial struct MemoryPackReader
         value3 = Unsafe.ReadUnaligned<T3>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()));
         value4 = Unsafe.ReadUnaligned<T4>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()));
         value5 = Unsafe.ReadUnaligned<T5>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -93,7 +93,7 @@ public ref partial struct MemoryPackReader
         value4 = Unsafe.ReadUnaligned<T4>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()));
         value5 = Unsafe.ReadUnaligned<T5>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()));
         value6 = Unsafe.ReadUnaligned<T6>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -115,7 +115,7 @@ public ref partial struct MemoryPackReader
         value5 = Unsafe.ReadUnaligned<T5>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()));
         value6 = Unsafe.ReadUnaligned<T6>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()));
         value7 = Unsafe.ReadUnaligned<T7>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -139,7 +139,7 @@ public ref partial struct MemoryPackReader
         value6 = Unsafe.ReadUnaligned<T6>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()));
         value7 = Unsafe.ReadUnaligned<T7>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()));
         value8 = Unsafe.ReadUnaligned<T8>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -165,7 +165,7 @@ public ref partial struct MemoryPackReader
         value7 = Unsafe.ReadUnaligned<T7>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()));
         value8 = Unsafe.ReadUnaligned<T8>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()));
         value9 = Unsafe.ReadUnaligned<T9>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -193,7 +193,7 @@ public ref partial struct MemoryPackReader
         value8 = Unsafe.ReadUnaligned<T8>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()));
         value9 = Unsafe.ReadUnaligned<T9>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()));
         value10 = Unsafe.ReadUnaligned<T10>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -223,7 +223,7 @@ public ref partial struct MemoryPackReader
         value9 = Unsafe.ReadUnaligned<T9>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()));
         value10 = Unsafe.ReadUnaligned<T10>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()));
         value11 = Unsafe.ReadUnaligned<T11>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -255,7 +255,7 @@ public ref partial struct MemoryPackReader
         value10 = Unsafe.ReadUnaligned<T10>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()));
         value11 = Unsafe.ReadUnaligned<T11>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()));
         value12 = Unsafe.ReadUnaligned<T12>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -289,7 +289,7 @@ public ref partial struct MemoryPackReader
         value11 = Unsafe.ReadUnaligned<T11>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()));
         value12 = Unsafe.ReadUnaligned<T12>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()));
         value13 = Unsafe.ReadUnaligned<T13>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -325,7 +325,7 @@ public ref partial struct MemoryPackReader
         value12 = Unsafe.ReadUnaligned<T12>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()));
         value13 = Unsafe.ReadUnaligned<T13>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()));
         value14 = Unsafe.ReadUnaligned<T14>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -363,7 +363,7 @@ public ref partial struct MemoryPackReader
         value13 = Unsafe.ReadUnaligned<T13>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()));
         value14 = Unsafe.ReadUnaligned<T14>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()));
         value15 = Unsafe.ReadUnaligned<T15>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -372,7 +372,7 @@ public ref partial struct MemoryPackReader
         var size = Unsafe.SizeOf<T1>();
         ref var spanRef = ref GetSpanReference(size);
         value1 = Unsafe.ReadUnaligned<T1>(ref spanRef);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -382,7 +382,7 @@ public ref partial struct MemoryPackReader
         ref var spanRef = ref GetSpanReference(size);
         value1 = Unsafe.ReadUnaligned<T1>(ref spanRef);
         value2 = Unsafe.ReadUnaligned<T2>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -393,7 +393,7 @@ public ref partial struct MemoryPackReader
         value1 = Unsafe.ReadUnaligned<T1>(ref spanRef);
         value2 = Unsafe.ReadUnaligned<T2>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()));
         value3 = Unsafe.ReadUnaligned<T3>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -405,7 +405,7 @@ public ref partial struct MemoryPackReader
         value2 = Unsafe.ReadUnaligned<T2>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()));
         value3 = Unsafe.ReadUnaligned<T3>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()));
         value4 = Unsafe.ReadUnaligned<T4>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -418,7 +418,7 @@ public ref partial struct MemoryPackReader
         value3 = Unsafe.ReadUnaligned<T3>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()));
         value4 = Unsafe.ReadUnaligned<T4>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()));
         value5 = Unsafe.ReadUnaligned<T5>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -432,7 +432,7 @@ public ref partial struct MemoryPackReader
         value4 = Unsafe.ReadUnaligned<T4>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()));
         value5 = Unsafe.ReadUnaligned<T5>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()));
         value6 = Unsafe.ReadUnaligned<T6>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -447,7 +447,7 @@ public ref partial struct MemoryPackReader
         value5 = Unsafe.ReadUnaligned<T5>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()));
         value6 = Unsafe.ReadUnaligned<T6>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()));
         value7 = Unsafe.ReadUnaligned<T7>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -463,7 +463,7 @@ public ref partial struct MemoryPackReader
         value6 = Unsafe.ReadUnaligned<T6>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()));
         value7 = Unsafe.ReadUnaligned<T7>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()));
         value8 = Unsafe.ReadUnaligned<T8>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -480,7 +480,7 @@ public ref partial struct MemoryPackReader
         value7 = Unsafe.ReadUnaligned<T7>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()));
         value8 = Unsafe.ReadUnaligned<T8>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()));
         value9 = Unsafe.ReadUnaligned<T9>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -498,7 +498,7 @@ public ref partial struct MemoryPackReader
         value8 = Unsafe.ReadUnaligned<T8>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()));
         value9 = Unsafe.ReadUnaligned<T9>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()));
         value10 = Unsafe.ReadUnaligned<T10>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -517,7 +517,7 @@ public ref partial struct MemoryPackReader
         value9 = Unsafe.ReadUnaligned<T9>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()));
         value10 = Unsafe.ReadUnaligned<T10>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()));
         value11 = Unsafe.ReadUnaligned<T11>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -537,7 +537,7 @@ public ref partial struct MemoryPackReader
         value10 = Unsafe.ReadUnaligned<T10>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()));
         value11 = Unsafe.ReadUnaligned<T11>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()));
         value12 = Unsafe.ReadUnaligned<T12>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -558,7 +558,7 @@ public ref partial struct MemoryPackReader
         value11 = Unsafe.ReadUnaligned<T11>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()));
         value12 = Unsafe.ReadUnaligned<T12>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()));
         value13 = Unsafe.ReadUnaligned<T13>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -580,7 +580,7 @@ public ref partial struct MemoryPackReader
         value12 = Unsafe.ReadUnaligned<T12>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()));
         value13 = Unsafe.ReadUnaligned<T13>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()));
         value14 = Unsafe.ReadUnaligned<T14>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -603,7 +603,7 @@ public ref partial struct MemoryPackReader
         value13 = Unsafe.ReadUnaligned<T13>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()));
         value14 = Unsafe.ReadUnaligned<T14>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()));
         value15 = Unsafe.ReadUnaligned<T15>(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>()));
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
 }

--- a/src/MemoryPack.Core/MemoryPackReader.Unmanaged.tt
+++ b/src/MemoryPack.Core/MemoryPackReader.Unmanaged.tt
@@ -32,7 +32,7 @@ public ref partial struct MemoryPackReader
 <# for(var j = 2; j <= i; j++) { #>
         value<#= j #> = Unsafe.ReadUnaligned<T<#= j #>>(ref Unsafe.Add(ref spanRef, <#= MakeSize(j - 1) #>));
 <# } #>
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
 <# } } #>

--- a/src/MemoryPack.Core/MemoryPackReader.cs
+++ b/src/MemoryPack.Core/MemoryPackReader.cs
@@ -173,7 +173,7 @@ public ref partial struct MemoryPackReader
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void AdvanceUnsafe(int count)
+    internal void AdvanceUnsafe(int count)
     {
         bufferLength = bufferLength - count;
 #if NET7_0_OR_GREATER

--- a/src/MemoryPack.Core/MemoryPackReader.cs
+++ b/src/MemoryPack.Core/MemoryPackReader.cs
@@ -172,6 +172,19 @@ public ref partial struct MemoryPackReader
         consumed += count;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    void AdvanceUnsafe(int count)
+    {
+        bufferLength = bufferLength - count;
+#if NET7_0_OR_GREATER
+        bufferReference = ref Unsafe.Add(ref bufferReference, count);
+#else
+        bufferReference = bufferReference.Slice(count);
+#endif
+        advancedCount += count;
+        consumed += count;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     bool TryAdvanceSequence(int count)
     {
@@ -253,7 +266,7 @@ public ref partial struct MemoryPackReader
     public bool TryReadObjectHeader(out byte memberCount)
     {
         memberCount = GetSpanReference(1);
-        Advance(1);
+        AdvanceUnsafe(1);
         return memberCount != MemoryPackCode.NullObject;
     }
 
@@ -261,7 +274,7 @@ public ref partial struct MemoryPackReader
     public bool TryReadUnionHeader(out ushort tag)
     {
         var firstTag = GetSpanReference(1);
-        Advance(1);
+        AdvanceUnsafe(1);
         if (firstTag < MemoryPackCode.WideTag)
         {
             tag = firstTag;
@@ -283,7 +296,7 @@ public ref partial struct MemoryPackReader
     public bool TryReadCollectionHeader(out int length)
     {
         length = Unsafe.ReadUnaligned<int>(ref GetSpanReference(4));
-        Advance(4);
+        AdvanceUnsafe(4);
 
         // If collection-length is larger than buffer-length, it is invalid data.
         if (Remaining < length)
@@ -351,7 +364,7 @@ public ref partial struct MemoryPackReader
     public bool DangerousTryReadCollectionHeader(out int length)
     {
         length = Unsafe.ReadUnaligned<int>(ref GetSpanReference(4));
-        Advance(4);
+        AdvanceUnsafe(4);
 
         return length != MemoryPackCode.NullCollection;
     }
@@ -386,7 +399,7 @@ public ref partial struct MemoryPackReader
 
         var str = new string(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<byte, char>(ref src), length));
 
-        Advance(byteCount);
+        AdvanceUnsafe(byteCount);
 
         return str;
     }
@@ -443,7 +456,7 @@ public ref partial struct MemoryPackReader
 #endif
         }
 
-        Advance(utf8Length + 4);
+        AdvanceUnsafe(utf8Length + 4);
 
         return str;
     }
@@ -456,7 +469,7 @@ public ref partial struct MemoryPackReader
         var size = Unsafe.SizeOf<T1>();
         ref var spanRef = ref GetSpanReference(size);
         var value1 = Unsafe.ReadUnaligned<T1>(ref spanRef);
-        Advance(size);
+        AdvanceUnsafe(size);
         return value1;
     }
 
@@ -744,7 +757,7 @@ public ref partial struct MemoryPackReader
         ref var src = ref GetSpanReference(byteCount);
         var dest = AllocateUninitializedArray<T>(length);
         Unsafe.CopyBlockUnaligned(ref Unsafe.As<T, byte>(ref GetArrayDataReference(dest)), ref src, (uint)byteCount);
-        Advance(byteCount);
+        AdvanceUnsafe(byteCount);
 
         return dest;
     }
@@ -775,7 +788,7 @@ public ref partial struct MemoryPackReader
         ref var dest = ref Unsafe.As<T, byte>(ref GetArrayDataReference(value));
         Unsafe.CopyBlockUnaligned(ref dest, ref src, (uint)byteCount);
 
-        Advance(byteCount);
+        AdvanceUnsafe(byteCount);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -804,7 +817,7 @@ public ref partial struct MemoryPackReader
         ref var dest = ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value));
         Unsafe.CopyBlockUnaligned(ref dest, ref src, (uint)byteCount);
 
-        Advance(byteCount);
+        AdvanceUnsafe(byteCount);
     }
 
     #endregion
@@ -830,7 +843,7 @@ public ref partial struct MemoryPackReader
             ref var dest = ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)!);
             Unsafe.CopyBlockUnaligned(ref dest, ref src, (uint)byteCount);
 
-            Advance(byteCount);
+            AdvanceUnsafe(byteCount);
         }
         else
         {
@@ -873,7 +886,7 @@ public ref partial struct MemoryPackReader
             ref var dest = ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)!);
             Unsafe.CopyBlockUnaligned(ref dest, ref src, (uint)byteCount);
 
-            Advance(byteCount);
+            AdvanceUnsafe(byteCount);
         }
         else
         {
@@ -913,7 +926,7 @@ public ref partial struct MemoryPackReader
 
         var span = MemoryMarshal.CreateReadOnlySpan(ref src, byteCount);
 
-        Advance(byteCount);
+        AdvanceUnsafe(byteCount);
         view = span; // safe until call next GetSpanReference
     }
 }

--- a/src/MemoryPack.Core/MemoryPackWriter.Unmanaged.cs
+++ b/src/MemoryPack.Core/MemoryPackWriter.Unmanaged.cs
@@ -13,9 +13,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         var size = Unsafe.SizeOf<T1>();
         ref var spanRef = ref GetSpanReference(size);
         Unsafe.WriteUnaligned(ref spanRef, value1);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1>(byte propertyCount, scoped in T1 value1)
         where T1 : unmanaged
@@ -24,7 +24,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         ref var spanRef = ref GetSpanReference(size);
         Unsafe.WriteUnaligned(ref spanRef, propertyCount);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, 1), value1);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -36,9 +36,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         ref var spanRef = ref GetSpanReference(size);
         Unsafe.WriteUnaligned(ref spanRef, value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2>(byte propertyCount, scoped in T1 value1, scoped in T2 value2)
         where T1 : unmanaged
@@ -49,7 +49,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref spanRef, propertyCount);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, 1), value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + 1), value2);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -63,9 +63,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref spanRef, value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3)
         where T1 : unmanaged
@@ -78,7 +78,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, 1), value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + 1), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + 1), value3);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -94,9 +94,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4)
         where T1 : unmanaged
@@ -111,7 +111,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + 1), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + 1), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + 1), value4);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -129,9 +129,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5)
         where T1 : unmanaged
@@ -148,7 +148,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + 1), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + 1), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + 1), value5);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -168,9 +168,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6)
         where T1 : unmanaged
@@ -189,7 +189,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + 1), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + 1), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + 1), value6);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -211,9 +211,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7)
         where T1 : unmanaged
@@ -234,7 +234,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + 1), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + 1), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + 1), value7);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -258,9 +258,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8)
         where T1 : unmanaged
@@ -283,7 +283,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + 1), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + 1), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + 1), value8);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -309,9 +309,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9)
         where T1 : unmanaged
@@ -336,7 +336,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + 1), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + 1), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + 1), value9);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -364,9 +364,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10)
         where T1 : unmanaged
@@ -393,7 +393,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + 1), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + 1), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + 1), value10);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -423,9 +423,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11)
         where T1 : unmanaged
@@ -454,7 +454,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + 1), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + 1), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + 1), value11);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -486,9 +486,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12)
         where T1 : unmanaged
@@ -519,7 +519,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + 1), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + 1), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + 1), value12);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -553,9 +553,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13)
         where T1 : unmanaged
@@ -588,7 +588,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + 1), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + 1), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + 1), value13);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -624,9 +624,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()), value14);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14)
         where T1 : unmanaged
@@ -661,7 +661,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + 1), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + 1), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + 1), value14);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -699,9 +699,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()), value14);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>()), value15);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14, scoped in T15 value15)
         where T1 : unmanaged
@@ -738,7 +738,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + 1), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + 1), value14);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>() + 1), value15);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -747,9 +747,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         var size = Unsafe.SizeOf<T1>();
         ref var spanRef = ref GetSpanReference(size);
         Unsafe.WriteUnaligned(ref spanRef, value1);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1>(byte propertyCount, scoped in T1 value1)
     {
@@ -757,7 +757,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         ref var spanRef = ref GetSpanReference(size);
         Unsafe.WriteUnaligned(ref spanRef, propertyCount);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, 1), value1);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -767,9 +767,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         ref var spanRef = ref GetSpanReference(size);
         Unsafe.WriteUnaligned(ref spanRef, value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2>(byte propertyCount, scoped in T1 value1, scoped in T2 value2)
     {
@@ -778,7 +778,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref spanRef, propertyCount);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, 1), value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + 1), value2);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -789,9 +789,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref spanRef, value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3)
     {
@@ -801,7 +801,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, 1), value1);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + 1), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + 1), value3);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -813,9 +813,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4)
     {
@@ -826,7 +826,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + 1), value2);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + 1), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + 1), value4);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -839,9 +839,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5)
     {
@@ -853,7 +853,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + 1), value3);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + 1), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + 1), value5);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -867,9 +867,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6)
     {
@@ -882,7 +882,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + 1), value4);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + 1), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + 1), value6);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -897,9 +897,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7)
     {
@@ -913,7 +913,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + 1), value5);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + 1), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + 1), value7);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -929,9 +929,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8)
     {
@@ -946,7 +946,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + 1), value6);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + 1), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + 1), value8);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -963,9 +963,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9)
     {
@@ -981,7 +981,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + 1), value7);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + 1), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + 1), value9);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -999,9 +999,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10)
     {
@@ -1018,7 +1018,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + 1), value8);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + 1), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + 1), value10);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1037,9 +1037,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11)
     {
@@ -1057,7 +1057,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + 1), value9);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + 1), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + 1), value11);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1077,9 +1077,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12)
     {
@@ -1098,7 +1098,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + 1), value10);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + 1), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + 1), value12);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1119,9 +1119,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13)
     {
@@ -1141,7 +1141,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + 1), value11);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + 1), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + 1), value13);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1163,9 +1163,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()), value14);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14)
     {
@@ -1186,7 +1186,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + 1), value12);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + 1), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + 1), value14);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1209,9 +1209,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()), value14);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>()), value15);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14, scoped in T15 value15)
     {
@@ -1233,7 +1233,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + 1), value13);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + 1), value14);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>() + 1), value15);
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
 }

--- a/src/MemoryPack.Core/MemoryPackWriter.Unmanaged.tt
+++ b/src/MemoryPack.Core/MemoryPackWriter.Unmanaged.tt
@@ -32,9 +32,9 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
 <# for(var j = 2; j <= i; j++) { #>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, <#= MakeSize(j - 1) #>), value<#= j #>);
 <# } #>
-        Advance(size);
+        AdvanceUnsafe(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void <#= dangerous ? "Dangerous" : "" #>WriteUnmanagedWithObjectHeader<<#= MakeT(i) #>>(byte propertyCount, <#= MakeArgs(i) #>)
 <# if(!dangerous) { #>
@@ -48,7 +48,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
 <# for(var j = 2; j <= i; j++) { #>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, <#= MakeSize(j - 1) #> + 1), value<#= j #>);
 <# } #>
-        Advance(size);
+        AdvanceUnsafe(size);
     }
 
 <# } } #>

--- a/src/MemoryPack.Core/MemoryPackWriter.cs
+++ b/src/MemoryPack.Core/MemoryPackWriter.cs
@@ -149,7 +149,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void AdvanceUnsafe(int count)
+    internal void AdvanceUnsafe(int count)
     {
         bufferLength = bufferLength - count;
 #if NET7_0_OR_GREATER


### PR DESCRIPTION
Redundant checks were not removed by the JIT because bufferLength was in the field and also because of the possibility of overflow.

I pasted JIT asm for reference.
It is recommended to separate the window to see main and pr at the same time.

Envitonment
```
.net9.0
Windows11
13th Gen Intel(R) Core(TM) i7-13700F   2.10 GHz
```
<details>
<summary>main</summary>

```asm
; Assembly listing for method MemoryPack.MemoryPackWriter`1[System.__Canon]:WriteNullObjectHeader():this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 0 single block inlinees; 2 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rbx
       sub      rsp, 32
       mov      rbx, rcx

G_M000_IG02:                ;; offset=0x0008
       cmp      dword ptr [rbx+0x18], 0
       jg       SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x000E
       mov      rcx, rbx
       mov      r8d, 1
       call     [MemoryPack.MemoryPackWriter`1[System.__Canon]:RequestNewBuffer(int):this]

G_M000_IG04:                ;; offset=0x001D
       mov      rax, bword ptr [rbx+0x10]
       mov      byte  ptr [rax], 255
       mov      eax, dword ptr [rbx+0x18]
       dec      eax
       js       SHORT G_M000_IG06
       mov      dword ptr [rbx+0x18], eax
       inc      bword ptr [rbx+0x10]
       inc      dword ptr [rbx+0x1C]
       inc      dword ptr [rbx+0x24]

G_M000_IG05:                ;; offset=0x0038
       add      rsp, 32
       pop      rbx
       ret

G_M000_IG06:                ;; offset=0x003E
       call     [MemoryPack.MemoryPackSerializationException:ThrowInvalidAdvance()]
       int3

; Total bytes of code 69

; Assembly listing for method MemoryPack.MemoryPackWriter`1[System.__Canon]:WriteUnmanaged[int](byref):this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 0 single block inlinees; 2 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 40
       mov      qword ptr [rsp+0x20], rdx
       mov      rbx, rcx
       mov      rsi, r8

G_M000_IG02:                ;; offset=0x0011
       mov      rcx, qword ptr [rdx+0x18]
       mov      rcx, qword ptr [rcx+0x10]
       test     rcx, rcx
       je       SHORT G_M000_IG07

G_M000_IG03:                ;; offset=0x001E
       mov      rdx, rcx

G_M000_IG04:                ;; offset=0x0021
       cmp      dword ptr [rbx+0x18], 4
       jge      SHORT G_M000_IG06

G_M000_IG05:                ;; offset=0x0027
       mov      rcx, rbx
       mov      r8d, 4
       call     [MemoryPack.MemoryPackWriter`1[System.__Canon]:RequestNewBuffer(int):this]

G_M000_IG06:                ;; offset=0x0036
       mov      rax, bword ptr [rbx+0x10]
       mov      ecx, dword ptr [rsi]
       mov      dword ptr [rax], ecx
       mov      eax, dword ptr [rbx+0x18]
       add      eax, -4
       jns      SHORT G_M000_IG08
       jmp      SHORT G_M000_IG10

G_M000_IG07:                ;; offset=0x0048
       mov      rcx, rdx
       mov      rdx, 0x7FF8A68682F8
       call     CORINFO_HELP_RUNTIMEHANDLE_METHOD
       mov      rdx, rax
       jmp      SHORT G_M000_IG04

G_M000_IG08:                ;; offset=0x005F
       mov      dword ptr [rbx+0x18], eax
       add      bword ptr [rbx+0x10], 4
       add      dword ptr [rbx+0x1C], 4
       add      dword ptr [rbx+0x20], 4

G_M000_IG09:                ;; offset=0x006F
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret

G_M000_IG10:                ;; offset=0x0076
       call     [MemoryPack.MemoryPackSerializationException:ThrowInvalidAdvance()]
       int3

; Total bytes of code 125

; Assembly listing for method MemoryPack.MemoryPackReader:TryReadObjectHeader(byref):ubyte:this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 0 single block inlinees; 2 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rdi
       push     rsi
       push     rbx
       sub      rsp, 32
       mov      rbx, rcx
       mov      rsi, rdx

G_M000_IG02:                ;; offset=0x000D
       cmp      dword ptr [rbx+0x20], 0
       jg       SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x0013
       mov      rcx, rbx
       mov      edx, 1
       call     [MemoryPack.MemoryPackReader:GetNextSpan(int):byref:this]
       jmp      SHORT G_M000_IG05

G_M000_IG04:                ;; offset=0x0023
       mov      rax, bword ptr [rbx+0x18]

G_M000_IG05:                ;; offset=0x0027
       movzx    rcx, byte  ptr [rax]
       mov      byte  ptr [rsi], cl
       mov      edi, dword ptr [rbx+0x20]
       dec      edi
       jns      SHORT G_M000_IG07

G_M000_IG06:                ;; offset=0x0033
       mov      rcx, rbx
       mov      edx, 1
       call     [MemoryPack.MemoryPackReader:TryAdvanceSequence(int):ubyte:this]
       test     eax, eax
       jne      SHORT G_M000_IG08

G_M000_IG07:                ;; offset=0x0045
       mov      dword ptr [rbx+0x20], edi
       inc      bword ptr [rbx+0x18]
       inc      dword ptr [rbx+0x24]
       inc      dword ptr [rbx+0x28]

G_M000_IG08:                ;; offset=0x0052
       cmp      byte  ptr [rsi], 255
       setne    al
       movzx    rax, al

G_M000_IG09:                ;; offset=0x005B
       add      rsp, 32
       pop      rbx
       pop      rsi
       pop      rdi
       ret

; Total bytes of code 99

; Assembly listing for method MemoryPack.MemoryPackReader:ReadUnmanaged[int]():int:this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 0 single block inlinees; 2 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rdi
       push     rsi
       push     rbx
       sub      rsp, 32
       mov      rbx, rcx

G_M000_IG02:                ;; offset=0x000A
       cmp      dword ptr [rbx+0x20], 4
       jge      SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x0010
       mov      rcx, rbx
       mov      edx, 4
       call     [MemoryPack.MemoryPackReader:GetNextSpan(int):byref:this]
       jmp      SHORT G_M000_IG05

G_M000_IG04:                ;; offset=0x0020
       mov      rax, bword ptr [rbx+0x18]

G_M000_IG05:                ;; offset=0x0024
       mov      esi, dword ptr [rax]
       mov      edi, dword ptr [rbx+0x20]
       add      edi, -4
       jns      SHORT G_M000_IG07

G_M000_IG06:                ;; offset=0x002E
       mov      rcx, rbx
       mov      edx, 4
       call     [MemoryPack.MemoryPackReader:TryAdvanceSequence(int):ubyte:this]
       test     eax, eax
       jne      SHORT G_M000_IG08

G_M000_IG07:                ;; offset=0x0040
       mov      dword ptr [rbx+0x20], edi
       add      bword ptr [rbx+0x18], 4
       add      dword ptr [rbx+0x24], 4
       add      dword ptr [rbx+0x28], 4

G_M000_IG08:                ;; offset=0x0050
       mov      eax, esi

G_M000_IG09:                ;; offset=0x0052
       add      rsp, 32
       pop      rbx
       pop      rsi
       pop      rdi
       ret

; Total bytes of code 90

; Assembly listing for method MemoryPack.MemoryPackReader:ReadUnmanaged[int](byref):this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 0 single block inlinees; 2 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 40
       mov      rbx, rcx
       mov      rsi, rdx

G_M000_IG02:                ;; offset=0x000C
       cmp      dword ptr [rbx+0x20], 4
       jge      SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x0012
       mov      rcx, rbx
       mov      edx, 4
       call     [MemoryPack.MemoryPackReader:GetNextSpan(int):byref:this]
       jmp      SHORT G_M000_IG05

G_M000_IG04:                ;; offset=0x0022
       mov      rax, bword ptr [rbx+0x18]

G_M000_IG05:                ;; offset=0x0026
       mov      ecx, dword ptr [rax]
       mov      dword ptr [rsi], ecx
       mov      esi, dword ptr [rbx+0x20]
       add      esi, -4
       jns      SHORT G_M000_IG07

G_M000_IG06:                ;; offset=0x0032
       mov      rcx, rbx
       mov      edx, 4
       call     [MemoryPack.MemoryPackReader:TryAdvanceSequence(int):ubyte:this]
       test     eax, eax
       jne      SHORT G_M000_IG08

G_M000_IG07:                ;; offset=0x0044
       mov      dword ptr [rbx+0x20], esi
       add      bword ptr [rbx+0x18], 4
       add      dword ptr [rbx+0x24], 4
       add      dword ptr [rbx+0x28], 4

G_M000_IG08:                ;; offset=0x0054
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret

; Total bytes of code 91
```
</details>

<details>
<summary>pr</summary>

```asm
; Assembly listing for method MemoryPack.MemoryPackWriter`1[System.__Canon]:WriteNullObjectHeader():this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rbx
       sub      rsp, 32
       mov      rbx, rcx

G_M000_IG02:                ;; offset=0x0008
       cmp      dword ptr [rbx+0x18], 0
       jg       SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x000E
       mov      rcx, rbx
       mov      r8d, 1
       call     [MemoryPack.MemoryPackWriter`1[System.__Canon]:RequestNewBuffer(int):this]

G_M000_IG04:                ;; offset=0x001D
       mov      rax, bword ptr [rbx+0x10]
       mov      byte  ptr [rax], 255
       dec      dword ptr [rbx+0x18]
       inc      bword ptr [rbx+0x10]
       inc      dword ptr [rbx+0x1C]
       inc      dword ptr [rbx+0x24]

G_M000_IG05:                ;; offset=0x0031
       add      rsp, 32
       pop      rbx
       ret

; Total bytes of code 55

; Assembly listing for method MemoryPack.MemoryPackWriter`1[System.__Canon]:WriteUnmanaged[int](byref):this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 40
       mov      qword ptr [rsp+0x20], rdx
       mov      rbx, rcx
       mov      rsi, r8

G_M000_IG02:                ;; offset=0x0011
       mov      rcx, qword ptr [rdx+0x18]
       mov      rcx, qword ptr [rcx+0x10]
       test     rcx, rcx
       je       SHORT G_M000_IG08

G_M000_IG03:                ;; offset=0x001E
       mov      rdx, rcx

G_M000_IG04:                ;; offset=0x0021
       cmp      dword ptr [rbx+0x18], 4
       jge      SHORT G_M000_IG06

G_M000_IG05:                ;; offset=0x0027
       mov      rcx, rbx
       mov      r8d, 4
       call     [MemoryPack.MemoryPackWriter`1[System.__Canon]:RequestNewBuffer(int):this]

G_M000_IG06:                ;; offset=0x0036
       mov      rax, bword ptr [rbx+0x10]
       mov      ecx, dword ptr [rsi]
       mov      dword ptr [rax], ecx
       add      bword ptr [rbx+0x10], 4
       add      dword ptr [rbx+0x18], -4
       add      dword ptr [rbx+0x1C], 4
       add      dword ptr [rbx+0x20], 4

G_M000_IG07:                ;; offset=0x004F
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret

G_M000_IG08:                ;; offset=0x0056
       mov      rcx, rdx
       mov      rdx, 0x7FF8A68684A8
       call     CORINFO_HELP_RUNTIMEHANDLE_METHOD
       mov      rdx, rax
       jmp      SHORT G_M000_IG04

; Total bytes of code 109

; Assembly listing for method MemoryPack.MemoryPackReader:TryReadObjectHeader(byref):ubyte:this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 40
       mov      rbx, rcx
       mov      rsi, rdx

G_M000_IG02:                ;; offset=0x000C
       cmp      dword ptr [rbx+0x20], 0
       jg       SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x0012
       mov      rcx, rbx
       mov      edx, 1
       call     [MemoryPack.MemoryPackReader:GetNextSpan(int):byref:this]
       jmp      SHORT G_M000_IG05

G_M000_IG04:                ;; offset=0x0022
       mov      rax, bword ptr [rbx+0x18]

G_M000_IG05:                ;; offset=0x0026
       movzx    rax, byte  ptr [rax]
       mov      byte  ptr [rsi], al
       dec      dword ptr [rbx+0x20]
       inc      bword ptr [rbx+0x18]
       inc      dword ptr [rbx+0x24]
       inc      dword ptr [rbx+0x28]
       cmp      byte  ptr [rsi], 255
       setne    al
       movzx    rax, al

G_M000_IG06:                ;; offset=0x0041
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret

; Total bytes of code 72

; Assembly listing for method MemoryPack.MemoryPackReader:ReadUnmanaged[int]():int:this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rbx
       sub      rsp, 32
       mov      rbx, rcx

G_M000_IG02:                ;; offset=0x0008
       cmp      dword ptr [rbx+0x20], 4
       jge      SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x000E
       mov      rcx, rbx
       mov      edx, 4
       call     [MemoryPack.MemoryPackReader:GetNextSpan(int):byref:this]
       jmp      SHORT G_M000_IG05

G_M000_IG04:                ;; offset=0x001E
       mov      rax, bword ptr [rbx+0x18]

G_M000_IG05:                ;; offset=0x0022
       mov      eax, dword ptr [rax]
       add      dword ptr [rbx+0x20], -4
       add      bword ptr [rbx+0x18], 4
       add      dword ptr [rbx+0x24], 4
       add      dword ptr [rbx+0x28], 4

G_M000_IG06:                ;; offset=0x0035
       add      rsp, 32
       pop      rbx
       ret

; Total bytes of code 59

; Assembly listing for method MemoryPack.MemoryPackReader:ReadUnmanaged[int](byref):this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 40
       mov      rbx, rcx
       mov      rsi, rdx

G_M000_IG02:                ;; offset=0x000C
       cmp      dword ptr [rbx+0x20], 4
       jge      SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0x0012
       mov      rcx, rbx
       mov      edx, 4
       call     [MemoryPack.MemoryPackReader:GetNextSpan(int):byref:this]
       jmp      SHORT G_M000_IG05

G_M000_IG04:                ;; offset=0x0022
       mov      rax, bword ptr [rbx+0x18]

G_M000_IG05:                ;; offset=0x0026
       mov      eax, dword ptr [rax]
       mov      dword ptr [rsi], eax
       add      dword ptr [rbx+0x20], -4
       add      bword ptr [rbx+0x18], 4
       add      dword ptr [rbx+0x24], 4
       add      dword ptr [rbx+0x28], 4

G_M000_IG06:                ;; offset=0x003B
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret

; Total bytes of code 66
```
</details>