### PR TITLE
Add allows ref struct constraint to TBufferWriter for .NET 9+

### DIFF
--- a/src/MemoryPack.Core/Compression/BrotliCompressor.cs
+++ b/src/MemoryPack.Core/Compression/BrotliCompressor.cs
@@ -195,7 +195,9 @@ public
     }
 
     public void CopyTo<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> memoryPackWriter)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>
@@ -253,7 +255,9 @@ public
     }
 
     static int CompressCore<TBufferWriter>(ref BrotliEncoder encoder, ReadOnlySpan<byte> source, ref MemoryPackWriter<TBufferWriter> destBufferWriter, int? initialLength, bool isFinalBlock)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/Formatters/CollectionFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/CollectionFormatters.cs
@@ -55,7 +55,9 @@ namespace MemoryPack.Formatters
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SerializePackable<T, TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, List<T?>? value)
             where T : IMemoryPackable<T>
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+            where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
             where TBufferWriter : IBufferWriter<byte>
 #else
             where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/Formatters/CultureInfoFormatter.cs
+++ b/src/MemoryPack.Core/Formatters/CultureInfoFormatter.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using MemoryPack.Internal;
 
 namespace MemoryPack.Formatters;

--- a/src/MemoryPack.Core/Formatters/DynamicUnionFormatter.cs
+++ b/src/MemoryPack.Core/Formatters/DynamicUnionFormatter.cs
@@ -39,7 +39,7 @@ public sealed class DynamicUnionFormatter<T> : MemoryPackFormatter<T>
             value = default;
             return;
         }
-        
+
         if (tagToType.TryGetValue(tag, out var type))
         {
             object? v = value;

--- a/src/MemoryPack.Core/Formatters/InterfaceCollectionFormatters.cs
+++ b/src/MemoryPack.Core/Formatters/InterfaceCollectionFormatters.cs
@@ -42,7 +42,9 @@ namespace MemoryPack.Formatters
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TrySerializeOptimized<TBufferWriter, TCollection, TElement>(ref MemoryPackWriter<TBufferWriter> writer, [NotNullWhen(false)] scoped ref TCollection? value)
             where TCollection : IEnumerable<TElement>
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+            where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
             where TBufferWriter : IBufferWriter<byte>
 #else
             where TBufferWriter : class, IBufferWriter<byte>
@@ -75,7 +77,9 @@ namespace MemoryPack.Formatters
 
         public static void SerializeCollection<TBufferWriter, TCollection, TElement>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref TCollection? value)
             where TCollection : ICollection<TElement>
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+            where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
             where TBufferWriter : IBufferWriter<byte>
 #else
             where TBufferWriter : class, IBufferWriter<byte>
@@ -94,7 +98,9 @@ namespace MemoryPack.Formatters
 
         public static void SerializeReadOnlyCollection<TBufferWriter, TCollection, TElement>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref TCollection? value)
             where TCollection : IReadOnlyCollection<TElement>
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+            where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
             where TBufferWriter : IBufferWriter<byte>
 #else
             where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/Formatters/KeyValuePairFormatter.cs
+++ b/src/MemoryPack.Core/Formatters/KeyValuePairFormatter.cs
@@ -12,7 +12,9 @@ public static class KeyValuePairFormatter
     [Preserve]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Serialize<TKey, TValue, TBufferWriter>(IMemoryPackFormatter<TKey> keyFormatter, IMemoryPackFormatter<TValue> valueFormatter, ref MemoryPackWriter<TBufferWriter> writer, KeyValuePair<TKey?, TValue?> value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/IMemoryPackFormatter.cs
+++ b/src/MemoryPack.Core/IMemoryPackFormatter.cs
@@ -8,7 +8,9 @@ public interface IMemoryPackFormatter
 {
     [Preserve]
     void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref object? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct;
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>;
 #else
         where TBufferWriter : class, IBufferWriter<byte>;
@@ -22,7 +24,9 @@ public interface IMemoryPackFormatter<T>
 {
     [Preserve]
     void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref T? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct;
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>;
 #else
         where TBufferWriter : class, IBufferWriter<byte>;
@@ -36,7 +40,9 @@ public abstract class MemoryPackFormatter<T> : IMemoryPackFormatter<T>, IMemoryP
 {
     [Preserve]
     public abstract void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref T? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct;
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>;
 #else
         where TBufferWriter : class, IBufferWriter<byte>;

--- a/src/MemoryPack.Core/IMemoryPackable.cs
+++ b/src/MemoryPack.Core/IMemoryPackable.cs
@@ -22,8 +22,11 @@ public interface IMemoryPackable<T> : IMemoryPackFormatterRegister
 {
     // note: serialize parameter should be `ref readonly` but current lang spec can not.
     // see proposal https://github.com/dotnet/csharplang/issues/6010
-
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    static abstract void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref T? value)
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct;
+    static abstract void Deserialize(ref MemoryPackReader reader, scoped ref T? value);
+#elif NET7_0_OR_GREATER
     static abstract void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref T? value)
         where TBufferWriter : IBufferWriter<byte>;
     static abstract void Deserialize(ref MemoryPackReader reader, scoped ref T? value);

--- a/src/MemoryPack.Core/Internal/ReusableLinkedArrayBufferWriter.cs
+++ b/src/MemoryPack.Core/Internal/ReusableLinkedArrayBufferWriter.cs
@@ -165,7 +165,9 @@ public sealed class ReusableLinkedArrayBufferWriter : IBufferWriter<byte>
     }
 
     public void WriteToAndReset<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/MemoryPack.Core.csproj
+++ b/src/MemoryPack.Core/MemoryPack.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/MemoryPack.Core/MemoryPackFormatterProvider.cs
+++ b/src/MemoryPack.Core/MemoryPackFormatterProvider.cs
@@ -372,7 +372,9 @@ internal sealed class ErrorMemoryPackFormatter : IMemoryPackFormatter
     }
 
     public void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref object? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/MemoryPackReader.cs
+++ b/src/MemoryPack.Core/MemoryPackReader.cs
@@ -796,7 +796,7 @@ public ref partial struct MemoryPackReader
         var byteCount = length * Unsafe.SizeOf<T>();
         ref var src = ref GetSpanReference(byteCount);
 
-        if (value == null || value.Length != length)
+        if (value.IsEmpty || value.Length != length)
         {
             value = AllocateUninitializedArray<T>(length);
         }

--- a/src/MemoryPack.Core/MemoryPackSerializer.Deserialize.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializer.Deserialize.cs
@@ -15,7 +15,7 @@ public static partial class MemoryPackSerializer
 #if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 #endif
-        T>(ReadOnlySpan<byte> buffer, MemoryPackSerializerOptions? options = default)
+    T>(ReadOnlySpan<byte> buffer, MemoryPackSerializerOptions? options = default)
     {
         T? value = default;
         Deserialize(buffer, ref value, options);
@@ -26,7 +26,7 @@ public static partial class MemoryPackSerializer
 #if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 #endif
-        T>(ReadOnlySpan<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
+    T>(ReadOnlySpan<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
     {
         if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
@@ -62,7 +62,7 @@ public static partial class MemoryPackSerializer
 #if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 #endif
-        T>(in ReadOnlySequence<byte> buffer, MemoryPackSerializerOptions? options = default)
+    T>(in ReadOnlySequence<byte> buffer, MemoryPackSerializerOptions? options = default)
     {
         T? value = default;
         Deserialize<T>(buffer, ref value, options);
@@ -73,7 +73,7 @@ public static partial class MemoryPackSerializer
 #if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 #endif
-        T>(in ReadOnlySequence<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
+    T>(in ReadOnlySequence<byte> buffer, ref T? value, MemoryPackSerializerOptions? options = default)
     {
         if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
@@ -144,7 +144,7 @@ public static partial class MemoryPackSerializer
 #if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 #endif
-        T>(Stream stream, MemoryPackSerializerOptions? options = default, CancellationToken cancellationToken = default)
+    T>(Stream stream, MemoryPackSerializerOptions? options = default, CancellationToken cancellationToken = default)
     {
         if (stream is MemoryStream ms && ms.TryGetBuffer(out ArraySegment<byte> streamBuffer))
         {

--- a/src/MemoryPack.Core/MemoryPackSerializer.NonGenerics.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializer.NonGenerics.cs
@@ -32,7 +32,9 @@ public static partial class MemoryPackSerializer
     }
 
     public static unsafe void Serialize<TBufferWriter>(Type type, in TBufferWriter bufferWriter, object? value, MemoryPackSerializerOptions? options = default)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>
@@ -58,7 +60,9 @@ public static partial class MemoryPackSerializer
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Serialize<TBufferWriter>(Type type, ref MemoryPackWriter<TBufferWriter> writer, object? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/MemoryPackSerializer.Serialize.cs
+++ b/src/MemoryPack.Core/MemoryPackSerializer.Serialize.cs
@@ -86,7 +86,9 @@ public static partial class MemoryPackSerializer
     }
 
     public static unsafe void Serialize<T, TBufferWriter>(in TBufferWriter bufferWriter, in T? value, MemoryPackSerializerOptions? options = default)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>
@@ -154,7 +156,9 @@ public static partial class MemoryPackSerializer
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Serialize<T, TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, in T? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>

--- a/src/MemoryPack.Core/MemoryPackWriter.Unmanaged.cs
+++ b/src/MemoryPack.Core/MemoryPackWriter.Unmanaged.cs
@@ -15,7 +15,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref spanRef, value1);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1>(byte propertyCount, scoped in T1 value1)
         where T1 : unmanaged
@@ -38,7 +38,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2>(byte propertyCount, scoped in T1 value1, scoped in T2 value2)
         where T1 : unmanaged
@@ -65,7 +65,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3)
         where T1 : unmanaged
@@ -96,7 +96,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4)
         where T1 : unmanaged
@@ -131,7 +131,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5)
         where T1 : unmanaged
@@ -170,7 +170,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6)
         where T1 : unmanaged
@@ -213,7 +213,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7)
         where T1 : unmanaged
@@ -260,7 +260,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8)
         where T1 : unmanaged
@@ -311,7 +311,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9)
         where T1 : unmanaged
@@ -366,7 +366,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10)
         where T1 : unmanaged
@@ -425,7 +425,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11)
         where T1 : unmanaged
@@ -488,7 +488,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12)
         where T1 : unmanaged
@@ -555,7 +555,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13)
         where T1 : unmanaged
@@ -626,7 +626,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()), value14);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14)
         where T1 : unmanaged
@@ -701,7 +701,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>()), value15);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14, scoped in T15 value15)
         where T1 : unmanaged
@@ -749,7 +749,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref spanRef, value1);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1>(byte propertyCount, scoped in T1 value1)
     {
@@ -769,7 +769,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>()), value2);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2>(byte propertyCount, scoped in T1 value1, scoped in T2 value2)
     {
@@ -791,7 +791,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>()), value3);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3)
     {
@@ -815,7 +815,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>()), value4);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4)
     {
@@ -841,7 +841,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>()), value5);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5)
     {
@@ -869,7 +869,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>()), value6);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6)
     {
@@ -899,7 +899,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>()), value7);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7)
     {
@@ -931,7 +931,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>()), value8);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8)
     {
@@ -965,7 +965,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>()), value9);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9)
     {
@@ -1001,7 +1001,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>()), value10);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10)
     {
@@ -1039,7 +1039,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>()), value11);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11)
     {
@@ -1079,7 +1079,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>()), value12);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12)
     {
@@ -1121,7 +1121,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>()), value13);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13)
     {
@@ -1165,7 +1165,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>()), value14);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14)
     {
@@ -1211,7 +1211,7 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref spanRef, Unsafe.SizeOf<T1>() + Unsafe.SizeOf<T2>() + Unsafe.SizeOf<T3>() + Unsafe.SizeOf<T4>() + Unsafe.SizeOf<T5>() + Unsafe.SizeOf<T6>() + Unsafe.SizeOf<T7>() + Unsafe.SizeOf<T8>() + Unsafe.SizeOf<T9>() + Unsafe.SizeOf<T10>() + Unsafe.SizeOf<T11>() + Unsafe.SizeOf<T12>() + Unsafe.SizeOf<T13>() + Unsafe.SizeOf<T14>()), value15);
         Advance(size);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void DangerousWriteUnmanagedWithObjectHeader<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(byte propertyCount, scoped in T1 value1, scoped in T2 value2, scoped in T3 value3, scoped in T4 value4, scoped in T5 value5, scoped in T6 value6, scoped in T7 value7, scoped in T8 value8, scoped in T9 value9, scoped in T10 value10, scoped in T11 value11, scoped in T12 value12, scoped in T13 value13, scoped in T14 value14, scoped in T15 value15)
     {

--- a/src/MemoryPack.Core/MemoryPackWriter.cs
+++ b/src/MemoryPack.Core/MemoryPackWriter.cs
@@ -16,7 +16,9 @@ using static MemoryPack.Internal.MemoryMarshalEx;
 
 [StructLayout(LayoutKind.Auto)]
 public ref partial struct MemoryPackWriter<TBufferWriter>
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
     where TBufferWriter : IBufferWriter<byte>
 #else
     where TBufferWriter : class, IBufferWriter<byte>
@@ -24,7 +26,11 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
 {
     const int DepthLimit = 1000;
 
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    ref byte bufferWriterRef;
+    ref TBufferWriter bufferWriter => ref Unsafe.As<byte, TBufferWriter>(ref bufferWriterRef);
+    ref byte bufferReference;
+#elif NET7_0_OR_GREATER
     ref TBufferWriter bufferWriter;
     ref byte bufferReference;
 #else
@@ -45,7 +51,10 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
 
     public MemoryPackWriter(ref TBufferWriter writer, MemoryPackWriterOptionalState optionalState)
     {
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        this.bufferWriterRef = ref Unsafe.As<TBufferWriter, byte>(ref writer);
+        this.bufferReference = ref Unsafe.NullRef<byte>();
+#elif NET7_0_OR_GREATER
         this.bufferWriter = ref writer;
         this.bufferReference = ref Unsafe.NullRef<byte>();
 #else
@@ -63,7 +72,10 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
     // optimized ctor, avoid first GetSpan call if we can.
     public MemoryPackWriter(ref TBufferWriter writer, byte[] firstBufferOfWriter, MemoryPackWriterOptionalState optionalState)
     {
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        this.bufferWriterRef = ref Unsafe.As<TBufferWriter, byte>(ref writer);
+        this.bufferReference = ref GetArrayDataReference(firstBufferOfWriter);
+#elif NET7_0_OR_GREATER
         this.bufferWriter = ref writer;
         this.bufferReference = ref GetArrayDataReference(firstBufferOfWriter);
 #else
@@ -80,7 +92,10 @@ public ref partial struct MemoryPackWriter<TBufferWriter>
 
     public MemoryPackWriter(ref TBufferWriter writer, Span<byte> firstBufferOfWriter, MemoryPackWriterOptionalState optionalState)
     {
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        this.bufferWriterRef = ref Unsafe.As<TBufferWriter, byte>(ref writer);
+        this.bufferReference = ref MemoryMarshal.GetReference(firstBufferOfWriter);
+#elif NET7_0_OR_GREATER
         this.bufferWriter = ref writer;
         this.bufferReference = ref MemoryMarshal.GetReference(firstBufferOfWriter);
 #else

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -455,7 +455,7 @@ partial {{classOrStructOrRecord}} {{TypeName}}
             writer.AppendLine(code);
         }
 
-        for(int i = 0; i < containingTypeDeclarations.Count; ++i)
+        for (int i = 0; i < containingTypeDeclarations.Count; ++i)
         {
             writer.AppendLine("}");
         }

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
@@ -529,7 +529,7 @@ public partial class TypeMeta
             }
         }
 
-    // Union validations
+        // Union validations
     UNION_VALIDATIONS:
         if (IsUnion)
         {

--- a/src/MemoryPack.Streaming/MemoryPack.Streaming.csproj
+++ b/src/MemoryPack.Streaming/MemoryPack.Streaming.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);CS1591;CA2255</NoWarn>

--- a/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
+++ b/src/MemoryPack.UnityShims/MemoryPack.UnityShims.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/MemoryPack/MemoryPack.csproj
+++ b/src/MemoryPack/MemoryPack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net7.0;net8.0;net9.0;netstandard2.1</TargetFrameworks>
         <!-- This project is meta package -->
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <IncludeContentInPack>true</IncludeContentInPack>

--- a/tests/MemoryPack.Tests/MemoryPack.Tests.csproj
+++ b/tests/MemoryPack.Tests/MemoryPack.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/tests/MemoryPack.Tests/MethodRefTest.cs
+++ b/tests/MemoryPack.Tests/MethodRefTest.cs
@@ -51,7 +51,9 @@ public partial class EmitIdData
 
     [MemoryPackOnSerializing]
     static void WriteId<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref EmitIdData? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>

--- a/tests/MemoryPack.Tests/Models/MethodCall.cs
+++ b/tests/MemoryPack.Tests/Models/MethodCall.cs
@@ -96,7 +96,9 @@ public partial class MethodCall
 
     [MemoryPackOnSerializing]
     public static void OnSerializing_M1<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref MethodCall? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>
@@ -107,7 +109,9 @@ public partial class MethodCall
 
     [MemoryPackOnSerializing]
     public void OnSerializing_M2<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref MethodCall? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>
@@ -118,7 +122,9 @@ public partial class MethodCall
 
     [MemoryPackOnSerialized]
     public static void OnSerialized_M1<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref MethodCall? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>
@@ -130,7 +136,9 @@ public partial class MethodCall
 
     [MemoryPackOnSerialized]
     public void OnSerialized_M2<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref MethodCall? value)
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        where TBufferWriter : IBufferWriter<byte>, allows ref struct
+#elif NET7_0_OR_GREATER
         where TBufferWriter : IBufferWriter<byte>
 #else
         where TBufferWriter : class, IBufferWriter<byte>


### PR DESCRIPTION
Resolves #447 

**Overview**
This PR adds the C# 13 `allows ref struct` anti-constraint to the `TBufferWriter` generic parameter across `MemoryPackWriter` and related core interfaces for .NET 9+. This enables users to implement custom buffer writers as `ref struct`s, unlocking zero-allocation serialization for native and unmanaged memory arenas.

**The Problem Solved**
Implementing `IBufferWriter<byte>` normally forces a heap allocation for a `MemoryManager<T>` because `GetMemory()` must return a `Memory<byte>`. Since `MemoryPackWriter` strictly uses `GetSpan()`, this allocation is wasted. By allowing a `ref struct` buffer writer, consumers can skip the heap allocation entirely and throw `NotSupportedException` in their `GetMemory()` implementation.

**Implementation Details & CS9050 Workaround**
During implementation, updating `MemoryPackWriter<TBufferWriter>` to store the `TBufferWriter` as a `ref` field results in compiler error **CS9050: A ref field cannot refer to a ref struct**. Even though `MemoryPackWriter` itself is a `ref struct`, C# currently forbids declaring a `ref T` field if `T` is an anti-constraint.

To bypass this safely while maintaining zero-allocation performance, the internal field was mapped to a `ref byte`:

```csharp
#if NET9_0_OR_GREATER
    ref byte bufferWriterRef;
    ref TBufferWriter bufferWriter => ref Unsafe.As<byte, TBufferWriter>(ref bufferWriterRef);
#endif
```
Because `MemoryPackWriter` is a `ref struct`, the GC's tracking of `ref byte` is identical to tracking `ref TBufferWriter`. The memory is guaranteed not to escape the stack or pinned context.

**Breaking Changes**
* **Older Frameworks:** This change is wrapped in `#if NET9_0_OR_GREATER` compilation directives. Existing .NET 7 and .NET 8 users are completely unaffected.
* **.NET 9 Users:** This introduces a **source-breaking change** for custom formatters compiled against .NET 9. Anyone who has written a custom formatter by inheriting from `MemoryPackFormatter<T>` or using `[MemoryPackOnSerializing]` / `[MemoryPackOnSerialized]` with a `TBufferWriter` parameter will need to add the `allows ref struct` constraint to their method signatures to match the updated base class/interface.
* **Source Generator:** The `MemoryPack` Source Generator does **not** require updates. It emits explicit interface implementations (e.g., `static void IMemoryPackable<T>.Serialize<TBufferWriter>(...)`), which implicitly inherit the constraints from the interface.