### PR TITLE
allow generate unmanaged type with VersionTolerant or circular serialization

### DIFF
--- a/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Emitter.cs
@@ -193,7 +193,7 @@ using MemoryPack;
 
         if (!xmlDocument)
         {
-            if (type.IsUnmanagedType)
+            if (type.IsUnmanagedType && type.GenerateType is not GenerateType.VersionTolerant and not GenerateType.CircularReference)
             {
                 sb.Append("GenerateType unmanaged ");
             }
@@ -207,7 +207,7 @@ using MemoryPack;
         else
         {
             sb.AppendLine("/// <remarks>");
-            if (type.IsUnmanagedType)
+            if (type.IsUnmanagedType && type.GenerateType is not GenerateType.VersionTolerant and not GenerateType.CircularReference)
             {
                 sb.AppendLine("/// MemoryPack GenerateType: unmanaged<br/>");
             }
@@ -269,7 +269,7 @@ public partial class TypeMeta
 
         var serializeBody = "";
         var deserializeBody = "";
-        if (IsUnmanagedType)
+        if (IsUnmanagedType && GenerateType is not GenerateType.VersionTolerant and not GenerateType.CircularReference)
         {
             serializeBody = $$"""
         writer.WriteUnmanaged(value);

--- a/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
+++ b/src/MemoryPack.Generator/MemoryPackGenerator.Parser.cs
@@ -292,14 +292,8 @@ public partial class TypeMeta
             noError = false;
         }
 
-        if (this.IsUnmanagedType)
+        if (this.IsUnmanagedType && GenerateType is not GenerateType.VersionTolerant and not GenerateType.CircularReference)
         {
-            if (GenerateType is GenerateType.VersionTolerant)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.VersionTolerantOnUnmanagedStruct, syntax.Identifier.GetLocation(), Symbol.Name));
-                noError = false;
-            }
-
             var structLayoutFields = this.Symbol.GetAllMembers()
                 .OfType<IFieldSymbol>()
                 .Select(x =>

--- a/tests/MemoryPack.Tests/SourceGeneratorTests/GeneratorDiagnosticsTest.TypeScript.cs
+++ b/tests/MemoryPack.Tests/SourceGeneratorTests/GeneratorDiagnosticsTest.TypeScript.cs
@@ -206,7 +206,7 @@ public partial class Hoge
             """,
             "FullName.ts");
 
-        generatedCode.Should().Contain(
+        generatedCode.Replace("\r\n", "\n").Should().Contain(
             """
             export class FullName {
                 firstName: string;

--- a/tests/MemoryPack.Tests/SourceGeneratorTests/GeneratorDiagnosticsTest.cs
+++ b/tests/MemoryPack.Tests/SourceGeneratorTests/GeneratorDiagnosticsTest.cs
@@ -674,9 +674,9 @@ public partial class Tester
     }
 
     [Fact]
-    public void MEMPACK041_UnmanagedStructCannotBeVersionTolerant()
+    public void MEMPACK041_UnmanagedStructCanBeVersionTolerant()
     {
-        Compile(41, """
+        var code = """
 using MemoryPack;
 
 [MemoryPackable(GenerateType.VersionTolerant)]
@@ -685,7 +685,9 @@ public partial struct Tester
     [MemoryPackOrder(0)]
     public int I1 { get; init; }
 }
-""");
+""";
+        var (_, diagnostics) = CSharpGeneratorRunner.RunGenerator(code);
+        diagnostics.Length.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
fixes #440 by allowing unmanaged struct to be VersionTolerant or CircularReference. out of this only VersionTolerant is really useful because you can add fields to the struct later. ordinarily you can force this by adding a dummy object field to the struct.